### PR TITLE
fix script selection on linux

### DIFF
--- a/LANCommander/Services/ScriptService.cs
+++ b/LANCommander/Services/ScriptService.cs
@@ -17,7 +17,7 @@ namespace LANCommander.Services
 
             return files.Select(f =>
             {
-                var split = f.Split('\\');
+                var split = f.Split(Path.DirectorySeparatorChar);
 
                 return new Snippet()
                 {


### PR DESCRIPTION
Tiny fix for the add script dialog (currently causes a silent server error w/o feedback on the client)...

Sorry for being this small, but since you've removed the dashboard problem and pushed net8, this is one of the "worst" issues when quickly operating the UI.