### PR TITLE
Add UDP port for Beacon Broadcast to docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ services:
     volumes:
       - /path/to/appdata/config:/config
     ports:
-      - 1337:1337
+      - 1337:1337/tcp   # Webinterface
+      - 35891:35891/udp # Beacon Broadcast
     restart: unless-stopped
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,6 @@ services:
     volumes:
       - /path/to/appdata/config:/config
     ports:
-      - 1337:1337
+      - 1337:1337/tcp   # Webinterface
+      - 35891:35891/udp # Beacon Broadcast
     restart: unless-stopped


### PR DESCRIPTION
Hi!

I just used the new Docker Image and saw that the UDP port for the Beacon Broadcast is missing.
Here's a Link to the BeaconLib where the port is specified: https://github.com/rix0rrr/beacon/blob/master/BeaconLib/Beacon.cs#L19

Greetz :)
potter