### PR TITLE
Expansions/mods installation and uninstallation fixes

### DIFF
--- a/LANCommander.Playnite.Extension/DownloadQueueController.cs
+++ b/LANCommander.Playnite.Extension/DownloadQueueController.cs
@@ -1,4 +1,4 @@
-﻿using LANCommander.PlaynitePlugin.Models;
+using LANCommander.PlaynitePlugin.Models;
 using LANCommander.SDK;
 using LANCommander.SDK.Exceptions;
 using LANCommander.SDK.Helpers;
@@ -353,6 +353,9 @@ namespace LANCommander.PlaynitePlugin
 
                 try
                 {
+                    if (dependentGame.BaseGame == null)
+                        dependentGame.BaseGame = game;
+
                     RunInstallScript(dependentGame);
                     RunNameChangeScript(dependentGame);
                     RunKeyChangeScript(dependentGame);

--- a/LANCommander.Playnite.Extension/UninstallController.cs
+++ b/LANCommander.Playnite.Extension/UninstallController.cs
@@ -35,7 +35,8 @@ namespace LANCommander.PlaynitePlugin
 
                 try
                 {
-                    foreach (var manifest in manifests)
+                    // We should execute the uninstallation in reverse so that expansions and mods execute their uninstall scripts before the base game is uninstalled
+                    foreach (var manifest in manifests.Reverse())
                     {
                         var scriptPath = ScriptHelper.GetScriptFilePath(Game.InstallDirectory, manifest.Id, SDK.Enums.ScriptType.Uninstall);
 
@@ -61,12 +62,16 @@ namespace LANCommander.PlaynitePlugin
 
                 Plugin.PlayniteApi.Dialogs.ActivateGlobalProgress(progress =>
                 {
-                    Plugin.LANCommanderClient.Games.Uninstall(Game.InstallDirectory, Game.Id);
+                    // Ensure all extensions/mods are uninstalled as well before the base game
+                    foreach (var manifest in manifests.Reverse())
+                    {
+                        Plugin.LANCommanderClient.Games.Uninstall(Game.InstallDirectory, manifest.Id);
 
-                    var metadataPath = SDK.GameService.GetMetadataDirectoryPath(Game.InstallDirectory, Game.Id);
+                        var metadataPath = SDK.GameService.GetMetadataDirectoryPath(Game.InstallDirectory, manifest.Id);
 
-                    if (Directory.Exists(metadataPath))
-                        Directory.Delete(metadataPath, true);
+                        if (Directory.Exists(metadataPath))
+                            Directory.Delete(metadataPath, true);
+                    }
 
                     DirectoryHelper.DeleteEmptyDirectories(Game.InstallDirectory);
                 },


### PR DESCRIPTION
During installation, the server sets `BaseGame` to null to avoid a circular dependency, but if this is not set then the expansions/mods won't find their scripts. We set the `BaseGame` now before running the `Run*Script` functions.

Previously, during uninstallation, the expansions/mods were not uninstalled. Now we run the scripts in reverse (expansions/mods, then base game) and we do the same for deleting the files.

Closes #66.