### PR TITLE
Fix app permissions for auto updater

### DIFF
--- a/Docker/root/etc/s6-overlay/s6-rc.d/init-files-folders-config/run
+++ b/Docker/root/etc/s6-overlay/s6-rc.d/init-files-folders-config/run
@@ -19,3 +19,5 @@ fi
 # permissions
 lsiown -R abc:abc \
      /config
+lsiown -R abc:abc \
+     /app/LANCommander


### PR DESCRIPTION
The app doesn't launch on 0.9.0 without fixing the permissions in the container.