### PR TITLE
fix /app permissions

### DIFF
--- a/Docker/root/etc/s6-overlay/s6-rc.d/svc-lancommander/run
+++ b/Docker/root/etc/s6-overlay/s6-rc.d/svc-lancommander/run
@@ -1,6 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+lsiown -R abc:abc \
+     /app/LANCommander
+
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 \
         cd /app/LANCommander s6-setuidgid abc /app/LANCommander/LANCommander.Server


### PR DESCRIPTION
This should fix the docker permissions bugs that appears when updating:

```
lancommander  | Unhandled exception. System.UnauthorizedAccessException: Access to the path '/app/LANCommander/LANCommander.AutoUpdater' is denied.
lancommander  |  ---> System.IO.IOException: Permission denied
lancommander  |    --- End of inner exception stack trace ---
lancommander  |    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
lancommander  |    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
lancommander  |    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
lancommander  |    at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
lancommander  |    at System.IO.FileSystem.LinkOrCopyFile(String sourceFullPath, String destFullPath)
lancommander  |    at System.IO.FileSystem.MoveFile(String sourceFullPath, String destFullPath, Boolean overwrite)
lancommander  |    at System.IO.File.Move(String sourceFileName, String destFileName, Boolean overwrite)
lancommander  |    at LANCommander.Server.Program.Main(String[] args) in D:\a\LANCommander\LANCommander\LANCommander.Server\Program.cs:line 341
lancommander  |    at LANCommander.Server.Program.Main(String[] args) in D:\a\LANCommander\LANCommander\LANCommander.Server\Program.cs:line 368
lancommander  |    at LANCommander.Server.Program.<Main>(String[] args)
lancommander  | warn: Microsoft.AspNetCore.DataProtection.Repositories.EphemeralXmlRepository[50]
lancommander  |       Using an in-memory repository. Keys will not be persisted to storage.
lancommander  | warn: Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager[59]
lancommander  |       Neither user profile nor HKLM registry available. Using an ephemeral key repository. Protected data will be unavailable when application exits.
lancommander  | warn: Microsoft.EntityFrameworkCore.Model.Validation[10625]
lancommander  |       The foreign key property 'ServerConsole.ServerId1' was created in shadow state because a conflicting property with the simple name 'ServerId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
lancommander  | warn: Microsoft.EntityFrameworkCore.Model.Validation[10625]
lancommander  |       The foreign key property 'ServerHttpPath.ServerId1' was created in shadow state because a conflicting property with the simple name 'ServerId' exists in the entity type, but is either not mapped, is already used for another relationship, or is incompatible with the associated primary key type. See https://aka.ms/efcore-relationships for information on mapping relationships in EF Core.
lancommander  | info: Microsoft.EntityFrameworkCore.Database.Command[20101]
lancommander  |       Executed DbCommand (6ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
lancommander  |       SELECT COUNT(*) FROM "sqlite_master" WHERE "name" = '__EFMigrationsHistory' AND "type" = 'table';
lancommander  | info: Microsoft.EntityFrameworkCore.Database.Command[20101]
lancommander  |       Executed DbCommand (1ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
lancommander  |       SELECT "MigrationId", "ProductVersion"
lancommander  |       FROM "__EFMigrationsHistory"
lancommander  |       ORDER BY "MigrationId";
lancommander  | Unhandled exception. System.UnauthorizedAccessException: Access to the path '/app/LANCommander/LANCommander.AutoUpdater' is denied.
lancommander  |  ---> System.IO.IOException: Permission denied
lancommander  |    --- End of inner exception stack trace ---
lancommander  |    at Interop.ThrowExceptionForIoErrno(ErrorInfo errorInfo, String path, Boolean isDirError)
lancommander  |    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String path, OpenFlags flags, Int32 mode, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
lancommander  |    at Microsoft.Win32.SafeHandles.SafeFileHandle.Open(String fullPath, FileMode mode, FileAccess access, FileShare share, FileOptions options, Int64 preallocationSize, UnixFileMode openPermissions, Int64& fileLength, UnixFileMode& filePermissions, Boolean failForSymlink, Boolean& wasSymlink, Func`4 createOpenException)
lancommander  |    at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
lancommander  |    at System.IO.FileSystem.LinkOrCopyFile(String sourceFullPath, String destFullPath)
lancommander  |    at System.IO.FileSystem.MoveFile(String sourceFullPath, String destFullPath, Boolean overwrite)
lancommander  |    at System.IO.File.Move(String sourceFileName, String destFileName, Boolean overwrite)
lancommander  |    at LANCommander.Server.Program.Main(String[] args) in D:\a\LANCommander\LANCommander\LANCommander.Server\Program.cs:line 341
lancommander  |    at LANCommander.Server.Program.Main(String[] args) in D:\a\LANCommander\LANCommander\LANCommander.Server\Program.cs:line 368
lancommander  |    at LANCommander.Server.Program.<Main>(String[] args)
```