### PR TITLE
Bumping csproj version to 1.0.3

### DIFF
--- a/LANCommander.SDK/LANCommander.SDK.csproj
+++ b/LANCommander.SDK/LANCommander.SDK.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-	  <Version>1.0.0</Version>
+	  <Version>1.0.3</Version>
 	  <Authors>pathartl</Authors>
 	  <Company>LANCommander</Company>
 	  <Description>A .NET library for interacting with a LANCommander server</Description>

--- a/LANCommander.Server/LANCommander.Server.csproj
+++ b/LANCommander.Server/LANCommander.Server.csproj
@@ -6,7 +6,7 @@
     <UserSecretsId>aspnet-LANCommander-C1F79CFA-9767-4AD7-BD5A-2549F8328A2D</UserSecretsId>
     <ApplicationIcon>wwwroot\favicon.ico</ApplicationIcon>
     <TypeScriptModuleKind>none</TypeScriptModuleKind>
-	<Version>1.0.0</Version>
+	<Version>1.0.3</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Bumping this version as it was confusing me in https://github.com/LANCommander/LANCommander/issues/133

Realistically when developing it would be good for this to match latest imo.