### PR TITLE
Add Installation Size Info

### DIFF
--- a/LANCommander.Launcher.Data/Migrations/20241211152242_AddInstallSizeToGame.Designer.cs
+++ b/LANCommander.Launcher.Data/Migrations/20241211152242_AddInstallSizeToGame.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LANCommander.Launcher.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LANCommander.Launcher.Data.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20241211152242_AddInstallSizeToGame")]
+    partial class AddInstallSizeToGame
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/LANCommander.Launcher.Data/Migrations/20241211152242_AddInstallSizeToGame.cs
+++ b/LANCommander.Launcher.Data/Migrations/20241211152242_AddInstallSizeToGame.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LANCommander.Launcher.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInstallSizeToGame : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+            migrationBuilder.AddColumn<double>(
+                name: "TotalSizeInGb",
+                table: "Games",
+                type: "REAL",
+                nullable: false,
+                defaultValue: 0.0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TotalSizeInGb",
+                table: "Games");
+        }
+    }
+}

--- a/LANCommander.Launcher.Data/Models/Game.cs
+++ b/LANCommander.Launcher.Data/Models/Game.cs
@@ -34,6 +34,7 @@ namespace LANCommander.Launcher.Data.Models
         public Guid? EngineId { get; set; }
         [ForeignKey(nameof(EngineId))]
         public virtual Engine Engine { get; set; }
+        public double TotalSizeInGb { get; set; }
 
         public virtual ICollection<MultiplayerMode>? MultiplayerModes { get; set; } = new List<MultiplayerMode>();
         public virtual ICollection<Genre>? Genres { get; set; } = new List<Genre>();

--- a/LANCommander.Launcher.Services/ImportService.cs
+++ b/LANCommander.Launcher.Services/ImportService.cs
@@ -247,6 +247,7 @@ namespace LANCommander.Launcher.Services
                             localGame.Type = (Data.Enums.GameType)(int)remoteGame.Type;
                             localGame.BaseGameId = remoteGame.BaseGame?.Id;
                             localGame.Singleplayer = remoteGame.Singleplayer;
+                            localGame.TotalSizeInGb = remoteGame.TotalSizeInGb;
 
                             #region Update Game Engine
                             if (remoteGame.Engine == null && localGame.Engine != null)

--- a/LANCommander.Launcher/LANCommander.Launcher.csproj
+++ b/LANCommander.Launcher/LANCommander.Launcher.csproj
@@ -56,13 +56,13 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Emzi0767.NtfsDataStreams" Version="1.0.0" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
-        <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.5" />
-        <PackageReference Include="Photino.Blazor" Version="3.1.10" />
+        <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.6" />
+        <PackageReference Include="Photino.Blazor" Version="3.2.0" />
         <PackageReference Include="Photino.Blazor.CustomWindow" Version="1.3.1" />
-        <PackageReference Include="Photino.NET" Version="3.1.18" />
+        <PackageReference Include="Photino.NET" Version="3.2.3" />
         <PackageReference Include="rix0rrr.BeaconLib" Version="1.0.2" />
-        <PackageReference Include="Serilog" Version="4.0.1" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Serilog" Version="4.2.0" />
+        <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
         <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />
     </ItemGroup>

--- a/LANCommander.Launcher/UI/Library/Index.razor
+++ b/LANCommander.Launcher/UI/Library/Index.razor
@@ -64,6 +64,9 @@
                                     }
                                 </SpaceItem>
                                 <SpaceItem>
+                                      <Statistic Title="Installation Size" Value="@GetTotalSizeInGb(SelectedGame)" />
+                                </SpaceItem>
+                                <SpaceItem>
                                     <Statistic Title="Play Time" Value="@GetPlayTime(SelectedGame)" />
                                 </SpaceItem>
                                 <SpaceItem>
@@ -321,5 +324,9 @@
             return "Never";
         else
             return lastSession.End.Value.ToRelativeDate();
+    }
+
+    string GetTotalSizeInGb(Data.Models.Game game) {
+        return $"{game.TotalSizeInGb:F1} GB";
     }
 }

--- a/LANCommander.SDK/Models/Game.cs
+++ b/LANCommander.SDK/Models/Game.cs
@@ -14,6 +14,7 @@ namespace LANCommander.SDK.Models
         public bool Singleplayer { get; set; }
         public DateTime ReleasedOn { get; set; }
         public string InstallDirectory { get; set; }
+        public double TotalSizeInGb { get; set; }
         public GameType Type { get; set; }
         public Game BaseGame { get; set; }
         public Engine Engine { get; set; }

--- a/LANCommander.Server/AutoMapper.cs
+++ b/LANCommander.Server/AutoMapper.cs
@@ -11,7 +11,11 @@ namespace LANCommander.Server
             CreateMap<Data.Models.Company, SDK.Models.Company>();
             CreateMap<Data.Models.Collection, SDK.Models.Collection>();
             CreateMap<Data.Models.Engine, SDK.Models.Engine>();
-            CreateMap<Data.Models.Game, SDK.Models.Game>();
+            CreateMap<Data.Models.Game, SDK.Models.Game>()
+                            .ForMember(dest => dest.TotalSizeInGb, opt => opt.MapFrom(src =>
+                src.Archives != null
+                    ? src.Archives.Sum(a => a.CompressedSize) / (1024 * 1024 * 1024)
+                    : 0));
             CreateMap<Data.Models.GameSave, SDK.Models.GameSave>();
             CreateMap<Data.Models.Genre, SDK.Models.Genre>();
             CreateMap<Data.Models.Key, SDK.Models.Key>();


### PR DESCRIPTION
Adds Installation Size information on library index

Default value is 0, size is calculated from CompressedSize (UncompressedSize seems to not populate), I've assumed that sum of Archives would be final size (archive[0] + archive[1]), haven't tested yet how updating behaves.

Added TotalSizeInGb property to Game model, mapped from Server's game model

I'm no pro with C# and Visual Studio at all, feel free to give some tips :)