### PR TITLE
Fix error when trying to import with a local file

### DIFF
--- a/LANCommander.Server.Services/ArchiveService.cs
+++ b/LANCommander.Server.Services/ArchiveService.cs
@@ -1,4 +1,4 @@
-﻿using LANCommander.Server.Data;
+using LANCommander.Server.Data;
 using LANCommander.Server.Data.Models;
 using LANCommander.Helpers;
 using LANCommander.Server.Models;
@@ -41,18 +41,12 @@ namespace LANCommander.Server.Services
 
         public async Task<string> GetArchiveFileLocationAsync(Archive archive)
         {
-            string storageLocationPath;
-            
-            if (archive.StorageLocation != null)
-                storageLocationPath = archive.StorageLocation.Path;
-            else
+            if (archive.StorageLocation == null)
             {
-                var storageLocation = await storageLocationService.GetAsync(archive.StorageLocationId);
-                
-                storageLocationPath = storageLocation.Path;
+                archive.StorageLocation = await storageLocationService.GetAsync(archive.StorageLocationId);
             }
-            
-            return Path.Combine(storageLocationPath, archive.ObjectKey);
+
+            return Path.Combine(archive.StorageLocation.Path, archive.ObjectKey);
         }
 
         public async Task<string> GetArchiveFileLocationAsync(string objectKey)

--- a/LANCommander.Server/UI/Components/ArchiveUploader.razor
+++ b/LANCommander.Server/UI/Components/ArchiveUploader.razor
@@ -1,4 +1,4 @@
-﻿@using Hangfire;
+@using Hangfire;
 @using LANCommander.SDK.Enums
 @using LANCommander.Server.Jobs.Background;
 @inject ArchiveService ArchiveService


### PR DESCRIPTION
Fix the error when trying to import a game archive with a local file.

* **ArchiveService.cs**
  - Add a null check for `archive.StorageLocation` in the `GetArchiveFileLocationAsync` method.
  - Fetch `archive.StorageLocation` if it is null in the `GetArchiveFileLocationAsync` method.
  - Return the combined path using `archive.StorageLocation.Path` and `archive.ObjectKey`.

* **ArchiveUploader.razor**
  - No changes made in this file.

