### PR TITLE
Fix Blazor rejoin dialog font color being white, force to black

### DIFF
--- a/LANCommander.Server/Styles/app.scss
+++ b/LANCommander.Server/Styles/app.scss
@@ -19,3 +19,9 @@
 @use '_page-editor';
 @use '_uploader';
 @use '_mobile';
+
+// Fix Blazor rejoin dialog font color being white, force to black
+// see: https://github.com/dotnet/aspnetcore/issues/57453
+#components-reconnect-modal {
+    color: black !important;
+}


### PR DESCRIPTION
When the connection of the Blazor server is lost, the rejoin/reconnect dialog is not properly visible due to the black theme and the Blazor dialog inheriting the color.

|  | Broken    | Fix |
| -| -------- | ------- |
| Dashboard | ![Dashboard-Bad](https://github.com/user-attachments/assets/b473f78b-c34f-4bee-bfe3-92101ee877c4) | ![Dashboard-Fix](https://github.com/user-attachments/assets/e81a9109-e681-406d-8689-f0ad8ccb704b)  |
| Login | ![Login-Bad](https://github.com/user-attachments/assets/0d0c2883-1070-478d-a391-f76a4eb9c60e) | ![Login-Fix](https://github.com/user-attachments/assets/5f65664d-f505-49d3-9087-e2eaf7b37f83)  |