### PR TITLE
Reworked launcher download

### DIFF
--- a/LANCommander.Server.Services/Models/Settings.cs
+++ b/LANCommander.Server.Services/Models/Settings.cs
@@ -219,7 +219,14 @@ namespace LANCommander.Server.Services.Models
     public class LauncherSettings
     {
         public string StoragePath { get; set; } = "Launcher";
+        /// <summary>
+        /// Whether to include locally downloaded launcher files and provide these for download
+        /// </summary>
         public bool HostUpdates { get; set; } = true;
+        /// <summary>
+        /// Whether to include online launcher files to link to for download
+        /// </summary>
+        public bool IncludeOnlineUpdates { get; set; } = false;
         public string VersionOverride { get; set; } = "";
         public IEnumerable<LauncherArchitecture> Architectures { get; set; } = new[] { LauncherArchitecture.x64, LauncherArchitecture.arm64 };
         public IEnumerable<LauncherPlatform> Platforms { get; set; } = new[] { LauncherPlatform.Windows };

--- a/LANCommander.Server.Services/UpdateService.cs
+++ b/LANCommander.Server.Services/UpdateService.cs
@@ -25,6 +25,8 @@ namespace LANCommander.Server.Services
         IGitHubService gitHubService,
         ServerService serverService) : BaseService(logger)
     {
+        public const string ArtifactUrlBase = "/download/Launcher/";
+
         public async Task<IEnumerable<LauncherArtifact>> GetLauncherArtifactsAsync()
         {
             if (!_settings.Launcher.HostUpdates)
@@ -84,6 +86,7 @@ namespace LANCommander.Server.Services
         {
             var platform = LauncherPlatform.Windows;
             var architecture = LauncherArchitecture.x64;
+            var assetName = Path.GetFileName(name);
 
             if (name.Contains("Windows"))
                 platform = LauncherPlatform.Windows;
@@ -98,7 +101,7 @@ namespace LANCommander.Server.Services
                 architecture = LauncherArchitecture.arm64;
 
             if (String.IsNullOrWhiteSpace(url))
-                url = $"/Launcher/{name}";
+                url = $"{ArtifactUrlBase}{assetName}";
 
             return new LauncherArtifact
             {
@@ -250,12 +253,28 @@ namespace LANCommander.Server.Services
 
             applicationLifetime.StopApplication();
         }
+
+        public string GetLauncherFileLocation(LauncherArtifact artifact)
+        {
+            return GetLauncherFileLocation(artifact.Name);
+        }
+
+        public string GetLauncherFileLocation(string objectKey)
+        {
+            return Path.Combine(_settings.Launcher.StoragePath, objectKey);
+        }
+
+        public LauncherArtifact GetLauncherArtifact(string objectKey)
+        {
+            string name = Path.Combine(_settings.Launcher.StoragePath, objectKey);
+            return GetArtifactFromName(name);
+        }
     }
 
     public class LauncherArtifact
     {
-        public string Name { get; set; }
-        public string Url { get; set; }
+        public required string Name { get; set; }
+        public required string Url { get; set; }
         public LauncherPlatform Platform { get; set; }
         public LauncherArchitecture Architecture { get; set; }
     }

--- a/LANCommander.Server.Services/UpdateService.cs
+++ b/LANCommander.Server.Services/UpdateService.cs
@@ -29,10 +29,20 @@ namespace LANCommander.Server.Services
 
         public async Task<IEnumerable<LauncherArtifact>> GetLauncherArtifactsAsync()
         {
-            if (!_settings.Launcher.HostUpdates)
-                return await GetLauncherArtifactsFromGitHubAsync().ToListAsync();
+            List<LauncherArtifact> launchers = [];
 
-            return GetLauncherArtifactsFromLocalFiles();
+            if (_settings.Launcher.HostUpdates)
+            {
+                launchers.AddRange(GetLauncherArtifactsFromLocalFiles());
+            }
+
+            if (launchers.Count == 0 || _settings.Launcher.IncludeOnlineUpdates)
+            {
+                var githubLaunchers = await GetLauncherArtifactsFromGitHubAsync().ToListAsync();
+                launchers.AddRange(githubLaunchers);
+            }
+
+            return launchers;
         }
 
         public IEnumerable<LauncherArtifact> GetLauncherArtifactsFromLocalFiles()

--- a/LANCommander.Server.Services/UpdateService.cs
+++ b/LANCommander.Server.Services/UpdateService.cs
@@ -80,7 +80,7 @@ namespace LANCommander.Server.Services
                     logger.LogError($"No assets found for v{currentVersion.WithoutMetadata()}!");
                 
                 foreach (var asset in assets)
-                    yield return GetArtifactFromName(asset.Name, asset.BrowserDownloadUrl);
+                    yield return GetArtifactFromName(asset.Name, asset.BrowserDownloadUrl, isOnline: true, isPrerelease: release.Prerelease);
             }
 
             if (releaseChannel == ReleaseChannel.Nightly)
@@ -88,11 +88,11 @@ namespace LANCommander.Server.Services
                 var nightlyArtifacts = await gitHubService.GetNightlyArtifactsAsync(_settings.Launcher.VersionOverride);
                 
                 foreach (var artifact in nightlyArtifacts.Where(a => a.Name.Contains("LANCommander.Launcher")))
-                    yield return GetArtifactFromName(artifact.Name, artifact.ArchiveDownloadUrl);
+                    yield return GetArtifactFromName(artifact.Name, artifact.ArchiveDownloadUrl, isOnline: true, isPrerelease: true, isNightly: true);
             }
         }
 
-        private LauncherArtifact GetArtifactFromName(string name, string url = "")
+        private LauncherArtifact GetArtifactFromName(string name, string url = "", bool isOnline = false, bool isPrerelease = false, bool isNightly = false)
         {
             var platform = LauncherPlatform.Windows;
             var architecture = LauncherArchitecture.x64;
@@ -119,6 +119,9 @@ namespace LANCommander.Server.Services
                 Platform = platform,
                 Architecture = architecture,
                 Url = url,
+                IsOnline = isOnline,
+                IsPrerelease = isPrerelease,
+                IsNightly = isNightly,
             };
         }
 
@@ -287,5 +290,8 @@ namespace LANCommander.Server.Services
         public required string Url { get; set; }
         public LauncherPlatform Platform { get; set; }
         public LauncherArchitecture Architecture { get; set; }
+        public bool IsOnline { get; set; }
+        public bool IsPrerelease { get; set; }
+        public bool IsNightly { get; set; }
     }
 }

--- a/LANCommander.Server.Services/UpdateService.cs
+++ b/LANCommander.Server.Services/UpdateService.cs
@@ -36,9 +36,12 @@ namespace LANCommander.Server.Services
         public IEnumerable<LauncherArtifact> GetLauncherArtifactsFromLocalFiles()
         {
             var currentVersion = versionProvider.GetCurrentVersion();
-            var downloadedLaunchers = Directory.GetFiles(_settings.Launcher.StoragePath, $"LANCommander.Launcher.*v{currentVersion.WithoutMetadata()}.zip");
-            
-            foreach (var downloadedLauncher in downloadedLaunchers)
+            var downloadedLaunchers = Directory.GetFiles(_settings.Launcher.StoragePath, $"LANCommander.Launcher*v{currentVersion.WithoutMetadata()}.*");
+            var downloadedInstallers = Directory.GetFiles(_settings.Launcher.StoragePath, $"LANCommander.Launcher-{currentVersion.WithoutMetadata()}*Setup*.*");
+
+            var downloads = downloadedLaunchers.Concat(downloadedInstallers).Distinct();
+
+            foreach (var downloadedLauncher in downloads)
                 yield return GetArtifactFromName(downloadedLauncher);
         }
 

--- a/LANCommander.Server/Jobs/Background/DownloadLauncherArtifacts.cs
+++ b/LANCommander.Server/Jobs/Background/DownloadLauncherArtifacts.cs
@@ -22,7 +22,7 @@ namespace LANCommander.Server.Jobs.Background
 
             foreach (var artifact in allowedArtifacts)
             {
-                using (var op = logger?.BeginOperation(" Downloading launcher artifact {ArtifactName} from GitHub", artifact.Name))
+                using (var op = logger?.BeginOperation("Downloading launcher artifact {ArtifactName} from GitHub", artifact.Name))
                 {
                     if (!localArtifacts.Any(a => a.Name.EndsWith(artifact.Name)))
                     {
@@ -30,6 +30,7 @@ namespace LANCommander.Server.Jobs.Background
                         using (var fs = new FileStream(Path.Combine(settings.Launcher.StoragePath, artifact.Name), FileMode.Create))
                         {
                             await downloadStream.CopyToAsync(fs);
+                            op.Complete();
                         }
                     }
                 }

--- a/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
+++ b/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
@@ -12,7 +12,7 @@
                         Type="ButtonType.Text"
                         Block
                         Icon="@downloadLink.Icon"
-                        OnClick="() => NavigationManager.NavigateTo(downloadLink.Url)"
+                        OnClick="() => NavigationManager.NavigateTo(downloadLink.Url, true)"
                         Style="text-align: left">
                         @downloadLink.Name
                         

--- a/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
+++ b/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
@@ -6,6 +6,15 @@
     <Popover Trigger="new[] { Trigger.Hover }">
         <ContentTemplate>
             <Flex Vertical Gap="FlexGap.Small">
+                @if (IsInitializing)
+                {
+                    <span ita>Fetching Launchers &mldr;</span>
+                }
+                else if (DownloadLinks.Count() == 0) 
+                {
+                    <span>No Launchers available</span>
+                }
+
                 @foreach (var downloadLink in DownloadLinks)
                 {
                     <Button
@@ -15,7 +24,7 @@
                         OnClick="() => NavigationManager.NavigateTo(downloadLink.Url, true)"
                         Style="text-align: left">
                         @downloadLink.Name
-                        
+
                         @foreach (var tag in downloadLink.Tags)
                         {
                             <Tag Color="TagColor.Green">@tag</Tag>
@@ -25,7 +34,11 @@
             </Flex>
         </ContentTemplate>
         <ChildContent>
-            <Button Type="ButtonType.Primary" Size="ButtonSize.Large">
+            <Button Type="ButtonType.Primary" 
+                    Size="ButtonSize.Large" 
+                    Disabled="@(DownloadLinks.Count() == 0)"
+                    Loading="@(DownloadLinks.Count() == 0)"
+            >
                 Download Launcher
             </Button>
         </ChildContent>
@@ -41,6 +54,8 @@
         public string[] Tags { get; set; }
     }
 
+    bool IsInitializing = false;
+
     IEnumerable<DownloadLink> DownloadLinks = new List<DownloadLink>();
 
     readonly Hashtable _iconMap = new()
@@ -52,30 +67,38 @@
 
     protected override async Task OnInitializedAsync()
     {
-        var artifacts = await UpdateService.GetLauncherArtifactsAsync();
+        try
+        {
+            IsInitializing = true;
+            var artifacts = await UpdateService.GetLauncherArtifactsAsync();
 
-        DownloadLinks = artifacts
-            .OrderBy(a => a.Platform)
-            .ThenBy(a => a.Architecture)
-            .Select(a =>
-            {
-                var tags = new List<string>();
+            DownloadLinks = artifacts
+                .OrderBy(a => a.Platform)
+                .ThenBy(a => a.Architecture)
+                .Select(a =>
+                {
+                    var tags = new List<string>();
 
-                if (artifacts.Count(art => art.Platform == a.Platform && art.Architecture == a.Architecture) > 1)
-                {
-                    if (a.Url.ToLower().EndsWith(".exe"))
-                        tags.Add("exe");
-                    else if (a.Url.ToLower().EndsWith(".zip"))
-                        tags.Add("zip");
-                }
-                
-                return new DownloadLink
-                {
-                    Name = $"{a.Platform} ({a.Architecture})",
-                    Icon = _iconMap[a.Platform].ToString(),
-                    Url = a.Url,
-                    Tags = tags.ToArray()
-                };
-            });
+                    if (artifacts.Count(art => art.Platform == a.Platform && art.Architecture == a.Architecture) > 1)
+                    {
+                        if (a.Url.ToLower().EndsWith(".exe"))
+                            tags.Add("exe");
+                        else if (a.Url.ToLower().EndsWith(".zip"))
+                            tags.Add("zip");
+                    }
+
+                    return new DownloadLink
+                    {
+                        Name = $"{a.Platform} ({a.Architecture})",
+                        Icon = _iconMap[a.Platform].ToString(),
+                        Url = a.Url,
+                        Tags = tags.ToArray()
+                    };
+                });
+        }
+        finally
+        {
+            IsInitializing = false;
+        }
     }
 }

--- a/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
+++ b/LANCommander.Server/UI/Pages/Account/Components/LauncherDownloadButton.razor
@@ -17,19 +17,31 @@
 
                 @foreach (var downloadLink in DownloadLinks)
                 {
-                    <Button
-                        Type="ButtonType.Text"
-                        Block
-                        Icon="@downloadLink.Icon"
-                        OnClick="() => NavigationManager.NavigateTo(downloadLink.Url, true)"
-                        Style="text-align: left">
-                        @downloadLink.Name
+                    <Button Type="ButtonType.Text"
+                            Block
+                            Icon="@downloadLink.Icon"
+                            OnClick="() => NavigationManager.NavigateTo(downloadLink.Url, true)"
+                            Style="text-align: left">
+                        <GridRow Wrap="false" Align="@RowAlign.Middle" Justify="@RowJustify.SpaceBetween">
+                            <GridCol Flex=@("auto")>
+                                @downloadLink.Name
 
-                        @foreach (var tag in downloadLink.Tags)
-                        {
-                            <Tag Color="TagColor.Green">@tag</Tag>
-                        }
+                                @foreach (var tag in downloadLink.Tags)
+                                {
+                                    <Tag Icon="@tag.Icon" Color="@(tag.ColorOverride ?? TagColor.Green)">@tag.Name</Tag>
+                                }
+                            </GridCol>
+                            <GridCol Flex=@("none")>
+                                <div style="padding-left: 8px;">
+                                    @if (downloadLink.IsOnline)
+                                    {
+                                        <Icon Type="@IconType.Outline.Cloud" />
+                                    }
+                                </div>
+                            </GridCol>
+                        </GridRow>
                     </Button>
+
                 }
             </Flex>
         </ContentTemplate>
@@ -48,16 +60,30 @@
 @code {
     class DownloadLink
     {
+        public class Tag
+        {
+            public Tag(string name)
+            {
+                Name = name;
+                Icon = string.Empty;
+            }
+            public string Name { get; set; }
+            public string Icon { get; set; }
+            public TagColor? ColorOverride { get; set; }
+        }
+
         public string Name { get; set; }
         public string Url { get; set; }
         public string Icon { get; set; }
-        public string[] Tags { get; set; }
+        public Tag[] Tags { get; set; }
+        public bool IsOnline { get; set; }
     }
 
     bool IsInitializing = false;
 
     IEnumerable<DownloadLink> DownloadLinks = new List<DownloadLink>();
 
+    readonly string DefaultIcon = IconType.Fill.QuestionCircle;
     readonly Hashtable _iconMap = new()
     {
         [LauncherPlatform.Windows] = IconType.Fill.Windows,
@@ -77,22 +103,28 @@
                 .ThenBy(a => a.Architecture)
                 .Select(a =>
                 {
-                    var tags = new List<string>();
+                    var tags = new List<DownloadLink.Tag>();
 
                     if (artifacts.Count(art => art.Platform == a.Platform && art.Architecture == a.Architecture) > 1)
                     {
                         if (a.Url.ToLower().EndsWith(".exe"))
-                            tags.Add("exe");
+                            tags.Add(new DownloadLink.Tag("exe"));
                         else if (a.Url.ToLower().EndsWith(".zip"))
-                            tags.Add("zip");
+                            tags.Add(new DownloadLink.Tag("zip"));
                     }
+
+                    if (a.IsNightly)
+                        tags.Add(new DownloadLink.Tag("nightly") { Icon = IconType.Fill.Fire, ColorOverride = TagColor.Volcano });
+                    else if (a.IsPrerelease)
+                        tags.Add(new DownloadLink.Tag("pre") { ColorOverride = TagColor.Gold });
 
                     return new DownloadLink
                     {
                         Name = $"{a.Platform} ({a.Architecture})",
-                        Icon = _iconMap[a.Platform].ToString(),
+                        Icon = _iconMap[a.Platform]?.ToString() ?? DefaultIcon,
                         Url = a.Url,
-                        Tags = tags.ToArray()
+                        Tags = tags.ToArray(),
+                        IsOnline = a.IsOnline,
                     };
                 });
         }

--- a/LANCommander.Server/UI/Pages/Settings/Launcher.razor
+++ b/LANCommander.Server/UI/Pages/Settings/Launcher.razor
@@ -19,7 +19,11 @@
         <FormItem Label="Host Client Updates">
             <Switch @bind-Checked="context.Launcher.HostUpdates" />
         </FormItem>
-        
+
+        <FormItem Label="Always include Online Updates">
+            <Switch @bind-Checked="context.Launcher.IncludeOnlineUpdates" />
+        </FormItem>
+
         <FormItem Label="Architectures">
             <EnumSelect
                 TEnum="LauncherArchitecture"
@@ -27,7 +31,7 @@
                 Disabled="!context.Launcher.HostUpdates"
                 @bind-Values="context.Launcher.Architectures" />
         </FormItem>
-        
+
         <FormItem Label="Platforms">
             <EnumSelect
                 TEnum="LauncherPlatform"


### PR DESCRIPTION
Rework on launcher download. This includes the following:
- Fix for Launcher files not being listed on login page due to name change
- Enforce downloading Launcher on a new page (to ensure the download starts)
- Option to include online Launcher setup/zip files
- UI messaging of the download button when progress is being done (like initializing/querying installers) or no installer available
- UI icons for pre-release, nightly and cloud versions of installer files
- Fix error messages on downloading launcher stating error

Image of broken download:
<img src="https://github.com/user-attachments/assets/647655e2-9c49-4dde-a4b2-075e6b06dc7c" height="150" Title="Download-Broken" />

Here is a short video/demonstration (on initial setup):
https://github.com/user-attachments/assets/6b7f20e8-88c5-416b-8753-4711e67269c6




