### PR TITLE
Fix Launcher register error

### DIFF
--- a/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
@@ -25,7 +25,11 @@
         {
             await Validate();
         };
-        
+        AuthenticationService.OnRegister += async (sender, args) =>
+        {
+            await Validate();
+        };
+
         await Validate();
     }
 

--- a/LANCommander.Server.Services/AuthenticationService.cs
+++ b/LANCommander.Server.Services/AuthenticationService.cs
@@ -141,11 +141,11 @@ namespace LANCommander.Server.Services
             };
         }
 
-        public async Task<AuthToken> RegisterAsync(string userName, string password, string passwordConfirmation)
+        public async Task<AuthToken> RegisterAsync(string userName, string password)
         {
-            if (password != passwordConfirmation)
-                throw new UserRegistrationException("Passwords don't match");
-            
+            if (string.IsNullOrWhiteSpace(password))
+                throw new UserRegistrationException("Password is empty");
+
             var user = await userService.GetAsync(userName);
 
             if (user != null)

--- a/LANCommander.Server/Controllers/Api/AuthController.cs
+++ b/LANCommander.Server/Controllers/Api/AuthController.cs
@@ -27,7 +27,6 @@ namespace LANCommander.Server.Controllers.Api
     {
         public string UserName { get; set; }
         public string Password { get; set; }
-        public string PasswordConfirmation { get; set; }
     }
 
     [Route("api/[controller]")]
@@ -142,8 +141,7 @@ namespace LANCommander.Server.Controllers.Api
         {
             try
             {
-                var token = await AuthenticationService.RegisterAsync(model.UserName, model.Password,
-                    model.PasswordConfirmation);
+                var token = await AuthenticationService.RegisterAsync(model.UserName, model.Password);
 
                 return Ok(token);
             }


### PR DESCRIPTION
Fixes the issue with the Launcher (on at least v1.1.5) not being able to register

- Launcher/Client was sending mismatching `RegisterModel` data regarding `PasswordConfirmation`
- Server was rejecting request
- After fix, client was stuck on register view due not auth not being _validated_

Fixes: #233 

<details>
  <summary>Demonstration</summary>

https://github.com/user-attachments/assets/1d629c97-ccda-4107-bcb3-3dbec7b3784b

https://github.com/user-attachments/assets/e22cc111-de00-4719-a37a-7c6ce4f10e03
  
</details>