### PR TITLE
Block First-Time-Setup after its initial setup being done

### DIFF
--- a/LANCommander.Server.Data/Models/Role.cs
+++ b/LANCommander.Server.Data/Models/Role.cs
@@ -10,7 +10,13 @@ namespace LANCommander.Server.Data.Models
         public ICollection<Collection> Collections { get; set; }
         public ICollection<UserRole> UserRoles { get; set; }
         [NotMapped]
-        public ICollection<User> Users { get; set; }
+        public ICollection<User> Users 
+        {
+            get
+            {
+                return UserRoles?.Select(ur => ur.User).ToArray() ?? [];
+            }
+        }
 
         [Display(Name = "Created On")]
         public DateTime CreatedOn { get; set; }

--- a/LANCommander.Server.Data/Models/Role.cs
+++ b/LANCommander.Server.Data/Models/Role.cs
@@ -19,7 +19,7 @@ namespace LANCommander.Server.Data.Models
         }
 
         [Display(Name = "Created On")]
-        public DateTime CreatedOn { get; set; }
+        public DateTime CreatedOn { get; set; } = DateTime.UtcNow;
 
         public Guid? CreatedById { get; set; }
         [ForeignKey(nameof(CreatedById))]
@@ -28,7 +28,7 @@ namespace LANCommander.Server.Data.Models
         public User? CreatedBy { get; set; }
 
         [Display(Name = "Updated On")]
-        public DateTime UpdatedOn { get; set; }
+        public DateTime UpdatedOn { get; set; } = DateTime.UtcNow;
 
         public Guid? UpdatedById { get; set; }
         [ForeignKey(nameof(UpdatedById))]

--- a/LANCommander.Server.Data/Models/User.cs
+++ b/LANCommander.Server.Data/Models/User.cs
@@ -73,7 +73,7 @@ namespace LANCommander.Server.Data.Models
 
         [JsonIgnore]
         [Display(Name = "Created On")]
-        public DateTime CreatedOn { get; set; }
+        public DateTime CreatedOn { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
         public Guid? CreatedById { get; set; }
@@ -85,7 +85,7 @@ namespace LANCommander.Server.Data.Models
 
         [JsonIgnore]
         [Display(Name = "Updated On")]
-        public DateTime UpdatedOn { get; set; }
+        public DateTime UpdatedOn { get; set; } = DateTime.UtcNow;
 
         [JsonIgnore]
         public Guid? UpdatedById { get; set; }

--- a/LANCommander.Server.Services/SetupService.cs
+++ b/LANCommander.Server.Services/SetupService.cs
@@ -2,6 +2,7 @@
 using LANCommander.Server.Data;
 using LANCommander.Server.Data.Enums;
 using LANCommander.Server.Data.Models;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -13,8 +14,15 @@ namespace LANCommander.Server.Services
 {
     public class SetupService(
         ILogger<SetupService> logger,
+        UserManager<User> userManager,
         IServiceProvider serviceProvider) : BaseService(logger), IDisposable
     {
+        public async Task<bool> IsSetupInitialized()
+        {
+            var admins = await userManager.GetUsersInRoleAsync(RoleService.AdministratorRoleName);
+            return admins.Any();
+        }
+
         public async Task ChangeProviderAsync(DatabaseProvider provider, string connectionString)
         {
             DatabaseContext.Provider = provider;

--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Administrator.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Administrator.razor
@@ -1,6 +1,7 @@
 ﻿@page "/FirstTimeSetup/Administrator"
 @using LANCommander.Server.Services.Exceptions
 @layout FirstTimeSetupLayout
+@inject SetupService SetupService
 @inject RoleService RoleService
 @inject UserService UserService
 @inject NavigationManager NavigationManager
@@ -43,10 +44,9 @@
     protected override async Task OnInitializedAsync()
     {
         await Layout.ChangeCurrentStep(FirstTimeSetupStep.Administrator);
-        
-        var existingAdministrators = await RoleService.GetUsersAsync(RoleService.AdministratorRoleName);
-        
-        if (existingAdministrators.Any())
+
+        var isSetupInitialized = await SetupService.IsSetupInitialized();
+        if (isSetupInitialized)
             NavigationManager.NavigateTo("/");
     }
 
@@ -75,7 +75,7 @@
                 if (role == null)
                     role = await RoleService.AddAsync(new Role
                     {
-                        Name = RoleService.AdministratorRoleName
+                        Name = RoleService.AdministratorRoleName,
                     });
             }
             catch (AddRoleException ex)

--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Database.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Database.razor
@@ -51,6 +51,13 @@
     protected override async Task OnInitializedAsync()
     {
         await Layout.ChangeCurrentStep(FirstTimeSetupStep.Database);
+
+        if (Settings.DatabaseProvider != Data.Enums.DatabaseProvider.Unknown)
+        {
+            var isSetupInitialized = await SetupService.IsSetupInitialized();
+            if (isSetupInitialized)
+                NavigationManager.NavigateTo("/");
+        }
     }
 
     void OnDatabaseProviderChanged()

--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Metadata.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Metadata.razor
@@ -22,7 +22,7 @@
         <Input @bind-Value="context.IGDBClientId" />
     </FormItem>
     <FormItem Label="Client Secret">
-        <InputPassword @bind-Value="context.IGDBClientSecret" />
+        <InputPassword @bind-Value="context.IGDBClientSecret" AutoComplete="false" />
     </FormItem>
 
     <Divider Text="SteamGridDB Credentials" />
@@ -32,7 +32,7 @@
     </p>
 
     <FormItem Label="API Key">
-        <InputPassword @bind-Value="context.Media.SteamGridDbApiKey" />
+        <InputPassword @bind-Value="context.Media.SteamGridDbApiKey" AutoComplete="false" />
     </FormItem>
 
     <FormItem>

--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Metadata.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Metadata.razor
@@ -1,5 +1,6 @@
 ﻿@page "/FirstTimeSetup/Metadata"
 @layout FirstTimeSetupLayout
+@inject SetupService SetupService
 @inject NavigationManager NavigationManager
 @inject IMessageService MessageService
 @inject ILogger<Index> Logger
@@ -55,6 +56,13 @@
 
     protected override async Task OnInitializedAsync()
     {
+        var isSetupInitialized = await SetupService.IsSetupInitialized();
+        if (isSetupInitialized)
+        {
+            NavigationManager.NavigateTo("/");
+            return;
+        }
+
         await Layout.ChangeCurrentStep(FirstTimeSetupStep.Metadata);
 
         Settings = SettingService.GetSettings();

--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Paths.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Paths.razor
@@ -1,6 +1,7 @@
 ﻿@page "/FirstTimeSetup/Paths"
 @using LANCommander.SDK.Enums
 @layout FirstTimeSetupLayout
+@inject SetupService SetupService
 @inject StorageLocationService StorageLocationService
 @inject SetupService SetupService
 @inject NavigationManager NavigationManager
@@ -33,7 +34,7 @@
                     </Flex>
                 </ActionColumn>
             </Table>
-            
+
             <Flex Justify="FlexJustify.End">
                 <Button OnClick="AddArchiveStorageLocation" Type="@ButtonType.Primary">Add Path</Button>
             </Flex>
@@ -57,9 +58,9 @@
             <FilePicker Root="@RootPath" EntrySelectable="x => x is FileManagerDirectory" @bind-Value="@MediaStorageLocation.Path" OkText="Select Path" Title="Choose Path" OnSelected="(path) => OnPathSelected(MediaStorageLocation, path)" />
         </FormItem>
     }
-    
+
     <Divider Text="Backups" />
-    
+
     <FormItem>
         <FilePicker Root="@RootPath" EntrySelectable="x => x is FileManagerDirectory" @bind-Value="@Settings.Backups.StoragePath" OkText="Select Path" Title="Choose Path" OnSelected="(path) => Settings.Backups.StoragePath = OnPathSelected(path)" />
     </FormItem>
@@ -89,14 +90,14 @@
     [CascadingParameter] FirstTimeSetupLayout Layout { get; set; }
 
     ICollection<StorageLocation> ArchiveStorageLocations = new List<StorageLocation>();
-    
+
     StorageLocation MediaStorageLocation = new()
     {
         Path = Path.Combine(SettingService.WorkingDirectory, "Media"),
         Type = StorageLocationType.Media,
         Default = true,
     };
-    
+
     StorageLocation SavesStorageLocation = new()
     {
         Path = Path.Combine(SettingService.WorkingDirectory, "Saves"),
@@ -112,7 +113,14 @@
     protected override async Task OnInitializedAsync()
     {
         await Layout.ChangeCurrentStep(FirstTimeSetupStep.Paths);
-        
+
+        var isSetupInitialized = await SetupService.IsSetupInitialized();
+        if (isSetupInitialized)
+        {
+            NavigationManager.NavigateTo("/");
+            return;
+        }
+
         try
         {
             ArchiveStorageLocations = await StorageLocationService


### PR DESCRIPTION
Blocks First-Time-Setup being used after the setup was already done.

> [!NOTE]  
> Changes to `Role` and `User` model are present

- Redirects access on setup routes to _root_
- Also removed auto-complete on _password_ fields for API key and client secret to block browser storing respectively prompting to store the data
- `Role.Users` are now populated by `UserRoles`
- `CreatedOn` and `UpdatedOn` are default to UTC timestamp on `Role` and `User` model

Also fixes: #212 

<details>
  <summary>Demonstration</summary>

Broken: Setup can be called (to create admin account)

https://github.com/user-attachments/assets/40344fc9-f7bf-45e5-be0e-6319ae918b67

Fix: Access to first-time-setup routes are redirect

https://github.com/user-attachments/assets/7b0e0750-67f1-4c44-af5b-01522d219a96


</details>