### PR TITLE
Fix import multiplayer modes

### DIFF
--- a/LANCommander.Server.Data/UpdateEntityContext.cs
+++ b/LANCommander.Server.Data/UpdateEntityContext.cs
@@ -101,15 +101,8 @@ public class UpdateEntityContext<TEntity>
                 var updatedTrackedEntities = updatedEntities
                     .Select(e => trackedEntities.FirstOrDefault(t => t.Id == e.Id) ?? e)
                     .ToList();
-                
-                // Clear the existing collection and add all updated entities
-                existingEntities.Clear();
-                foreach (var entity in updatedTrackedEntities)
-                {
-                    existingEntities.Add(entity);
-                }
 
-                // Update values for existing entities
+                // Update values for existing entities first
                 foreach (var existingEntity in existingEntities)
                 {
                     var updatedEntity = updatedEntities.FirstOrDefault(e => e.Id == existingEntity.Id);
@@ -118,7 +111,14 @@ public class UpdateEntityContext<TEntity>
                         _context.Entry(existingEntity).CurrentValues.SetValues(updatedEntity);
                     }
                 }
-                    
+
+                // Clear the existing collection and add all updated entities
+                existingEntities.Clear();
+                foreach (var entity in updatedTrackedEntities)
+                {
+                    existingEntities.Add(entity);
+                }
+
                 _context.Entry(_entity).State = EntityState.Modified;
             }
         }

--- a/LANCommander.Server/PCGamingWikiClient.cs
+++ b/LANCommander.Server/PCGamingWikiClient.cs
@@ -1,5 +1,6 @@
 ﻿using HtmlAgilityPack;
 using LANCommander.SDK;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -13,6 +14,45 @@ namespace LANCommander.PCGamingWiki
 {
     public class PCGamingWikiClient
     {
+        #region Internal models
+
+        public class GetPageIdModel
+        {
+            public class Cargoquery
+            {
+                public class Title
+                {
+                    public string PageID { get; set; }
+                    public string Page { get; set; }
+
+                    [JsonProperty("Steam AppID")]
+                    public string SteamAppID { get; set; }
+                }
+                public Title title { get; set; }
+            }
+
+            public List<Cargoquery> cargoquery { get; } = new List<Cargoquery>();
+        }
+
+        public class GetPageContentModel
+        {
+            public class Parse
+            {
+                public class Text
+                {
+                    [JsonProperty("*")]
+                    public string content { get; set; }
+                }
+
+                public string title { get; set; }
+                public int pageid { get; set; }
+                public Text text { get; set; }
+            }
+            public Parse parse { get; set; }
+        }
+        
+        #endregion
+
         private HttpClient Client;
 
         public PCGamingWikiClient()
@@ -41,25 +81,38 @@ namespace LANCommander.PCGamingWiki
 
         public async Task<Dictionary<string, int>> GetMultiplayerPlayerCounts(string keyword)
         {
-            var url = await Search(keyword);
+            var pageId = await GetPageIDAsync(keyword);
+            if (pageId != null)
+            {
+                var pageContent = await GetPageContentAsync(pageId);
 
-            return await GetMultiplayerPlayerCounts(url);
+                var dom = new HtmlDocument();
+                dom.LoadHtml(pageContent ?? string.Empty);
+                return GetMultiplayerPlayerCounts(dom);
+            }
+
+            return [];
         }
 
-        public async Task<Dictionary<string, int>> GetMultiplayerPlayerCounts(Uri url)
+        public Dictionary<string, int> GetMultiplayerPlayerCounts(Uri url)
         {
+            if (url == null)
+                return [];
+
+            HtmlWeb web = new();
+            HtmlDocument dom = web.Load(url);
+            return GetMultiplayerPlayerCounts(dom);
+        }
+
+        protected Dictionary<string, int> GetMultiplayerPlayerCounts(HtmlDocument dom)
+        {
+            ArgumentNullException.ThrowIfNull(dom);
+
             var results = new Dictionary<string, int>();
 
-            if (url == null)
-                return results;
-
-            HtmlWeb web = new HtmlWeb();
-            HtmlDocument dom = web.Load(url);
-
             HtmlNode multiplayerTable = dom.GetElementbyId("table-network-multiplayer");
-
             if (multiplayerTable == null)
-                return null;
+                return results;
 
             var multiplayerRows = multiplayerTable.SelectNodes(".//tr[contains(@class, 'table-network-multiplayer-body-row')]");
             var multiplayerAbbrs = multiplayerTable.SelectNodes(".//abbr");
@@ -98,6 +151,53 @@ namespace LANCommander.PCGamingWiki
             }
 
             return results;
+        }
+
+        protected async Task<string?> GetPageIDAsync(string keyword)
+        {
+            try
+            {
+                string getPageIdUrl = $"https://www.pcgamingwiki.com/w/api.php?action=cargoquery&format=json&tables=Infobox_game&fields=Infobox_game._pageID%3DPageID%2C_pageName%3DPage%2CSteam_AppID&where=Infobox_game._pageName%3D%22{HttpUtility.UrlEncode(keyword)}%22&formatversion=1";
+
+                // HttpClient.GetFromJsonAsync<> does not seem to deserialize list properly (at least with the usedmodel)
+                // read json and parse via Newtonsoft lib
+                string getPageIdJson = await Client.GetStringAsync(getPageIdUrl);
+                var pageId = JsonConvert.DeserializeObject<GetPageIdModel>(getPageIdJson);
+
+                if (pageId == null || pageId.cargoquery == null || pageId.cargoquery.Count != 1)
+                    return null;
+
+                var title = pageId.cargoquery[0]?.title;
+                return title?.PageID;
+            }
+            catch (Exception ex)
+            {
+                // TODO: add logging
+                //Logger?.LogError(ex, $"Could not parse page id from PCGamingWiki for retrieving page with keyword {keyword}");
+            }
+
+            return null;
+        }
+
+        protected async Task<string?> GetPageContentAsync(string pageId)
+        {
+            try
+            {
+                string getPageContentUrl = $"https://www.pcgamingwiki.com/w/api.php?action=parse&format=json&prop=text&pageid={HttpUtility.UrlEncode(pageId)}";
+
+                // HttpClient.GetFromJsonAsync<> does not seem to deserialize list properly (at least with the usedmodel)
+                // read json and parse via Newtonsoft lib
+                string getPageContentJson = await Client.GetStringAsync(getPageContentUrl);
+                var pageContent = JsonConvert.DeserializeObject<GetPageContentModel>(getPageContentJson);
+                return pageContent?.parse?.text?.content;
+            }
+            catch (Exception ex)
+            {
+                // TODO: add logging
+                //Logger?.LogError(ex, $"Could not parse page content from PCGamingWiki for retrieving page with id {pageId}");
+            }
+
+            return null;
         }
     }
 }

--- a/LANCommander.Server/PCGamingWikiClient.cs
+++ b/LANCommander.Server/PCGamingWikiClient.cs
@@ -157,6 +157,9 @@ namespace LANCommander.PCGamingWiki
                         .Select(x => x.InnerText)
                         .Select(x => x.TrimEnd('.'));
                     notes = string.Join("\n", notelines ?? []);
+                    notes = notes.Replace("\n\n", ". ");
+                    notes = notes.ReplaceLineEndings("");
+                    notes = HttpUtility.HtmlDecode(notes);
                 }
 
                 if (type == null)

--- a/LANCommander.Server/UI/Pages/Games/Components/GameMetadataLookup.razor
+++ b/LANCommander.Server/UI/Pages/Games/Components/GameMetadataLookup.razor
@@ -212,25 +212,28 @@ else
 
         try
         {
-            var playerCounts = await PCGamingWikiClient.GetMultiplayerPlayerCounts(gameTitle);
+            var multiplayerInfo = await PCGamingWikiClient.GetMultiplayerPlayerInfo(gameTitle);
 
-            if (playerCounts != null)
+            if (multiplayerInfo != null)
             {
-                foreach (var playerCount in playerCounts)
+                foreach (var info in multiplayerInfo)
                 {
                     MultiplayerType type;
 
-                    switch (playerCount.Key)
+                    switch (info.MultiplayerType.ToLower())
                     {
-                        case "Local Play":
+                        case "local":
+                        case "local play":
                             type = MultiplayerType.Local;
                             break;
 
-                        case "LAN Play":
+                        case "lan":
+                        case "lan play":
                             type = MultiplayerType.LAN;
                             break;
 
-                        case "Online Play":
+                        case "online":
+                        case "online play":
                             type = MultiplayerType.Online;
                             break;
 
@@ -241,8 +244,9 @@ else
                     multiplayerModes.Add(new MultiplayerMode()
                     {
                         Type = type,
-                        MaxPlayers = playerCount.Value,
-                        MinPlayers = 2
+                        MaxPlayers = info.PlayerCount,
+                        MinPlayers = 2,
+                        Description = info.Notes,
                     });
                 }
             }


### PR DESCRIPTION
Fixes querying multiplayer modes from PCGaminigWiki.

> [!CAUTION]  
> The Update-Entity logic has changed.

- Scrapes/queries Wiki HTML page using its Cargoquery API for receiving the generated HTML page
- Parses _Notes_ and stores it as description
- Uses _HttpClient_ to retrieve the _JSON_ data and utilizes _Newtonsoft JSON converter_ to deserialize the data

<details>
  <summary><b>Demonstration</b></summary>

Broken: No data is received

https://github.com/user-attachments/assets/4bd8ce60-2f43-4806-9a6f-b013495afdf1

Fix: Data is received. Notes are stored as description.

https://github.com/user-attachments/assets/ed384fc2-2d12-4e57-81ff-f82fef116767

</details>


#### n.b. 1:

The commit 6780aa51df9b9f38543e3864d3a2bc80e7e28f69 is required as otherwise every new entry to insert into the database will be matched with the first new entry - as the default Guid matches for every single item.

<img src="https://github.com/user-attachments/assets/b782e9f9-efc9-4f9b-957f-5bdc61d96117" height="150" Title="DuplicateModes" />


#### n.b. 2:

PCGamingWiki might not properly provide a valid wiki page when requesting. The following HTMl is the response given by the request which requires JavaScript to proceed.

[wiki.html.txt](https://github.com/user-attachments/files/19897290/wiki.html.txt)
