### PR TITLE
Thumbnail file/image size reduction

### DIFF
--- a/LANCommander.Server.Services/MediaService.cs
+++ b/LANCommander.Server.Services/MediaService.cs
@@ -49,15 +49,17 @@ namespace LANCommander.Server.Services
                 await context.UpdateRelationshipAsync(m => m.StorageLocation);
             });
         }
-        
-        private Dictionary<MediaType, Size> ThumbnailSizes = new Dictionary<MediaType, Size>
+
+        private float ThumbnailPercentage = 0.40f;
+
+        private Dictionary<MediaType, (Size MinSize, Size MaxSize)> ThumbnailSizes = new Dictionary<MediaType, (Size MinSize, Size MaxSize)>
         {
-            { MediaType.Cover, new Size(600, 900) },
-            { MediaType.Manual, new Size(600, 900) },
-            { MediaType.Logo, new Size(640, 360) },
-            { MediaType.Background, new Size(1920, 1080) },
-            { MediaType.Icon, new Size(64, 64) },
-            { MediaType.Avatar, new Size(128, 128) }
+            { MediaType.Cover, (new Size(120, 180), MaxSize: new Size(240, 360)) },
+            { MediaType.Manual, (new Size(120, 180), new Size(180, 270)) },
+            { MediaType.Logo, (new Size(160, 90), new Size(320, 180)) },
+            { MediaType.Background, (new Size(320, 180), new Size(960, 540)) },
+            { MediaType.Icon, (new Size(32, 32), new Size(64, 64)) },
+            { MediaType.Avatar, (new Size(64, 64), new Size(128, 128)) }
         };
 
         public override async Task DeleteAsync(Media entity)
@@ -191,10 +193,13 @@ namespace LANCommander.Server.Services
                 {
                     using (var image = await Image.LoadAsync<Rgba32>(stream))
                     {
+                        var (MinSize, MaxSize) = ThumbnailSizes[media.Type];
+                        int thumbsizeX = (int)Math.Clamp(image.Width * ThumbnailPercentage, MinSize.Width, MaxSize.Width);
+                        int thumbsizeY = (int)Math.Clamp(image.Height * ThumbnailPercentage, MinSize.Height, MaxSize.Height);
                         var resizeOptions = new ResizeOptions
                         {
                             Mode = ResizeMode.Max,
-                            Size = ThumbnailSizes[media.Type],
+                            Size = new Size(thumbsizeX, thumbsizeY),
                             Sampler = KnownResamplers.Bicubic,
                         };
 


### PR DESCRIPTION
Reduces thumbnail media image size by 40%. Resulting size will be limited to the configured min and max size for the given media type (such as background, cover, etc.).

**Reasoning**:  
In cases of choosing/uploading smaller images, the thumbnails might be larger and take up more space than the original image. This is the case for the _official_ media assets of Steam.

Pre change:
```
61e6efbb-0051-42f2-bfbe-9f0cd5eab853           1285
61e6efbb-0051-42f2-bfbe-9f0cd5eab853.Thumb     1406
9978ccba-8b98-4d7c-942d-88667845331f         338949
9978ccba-8b98-4d7c-942d-88667845331f.Thumb   185106
b0dcb044-a636-4500-b6e3-0c4b0213d030          62970
b0dcb044-a636-4500-b6e3-0c4b0213d030.Thumb    66918
e5957556-c342-43b6-b808-192c68247ae7          71655
e5957556-c342-43b6-b808-192c68247ae7.Thumb   104724
```

**After change**:  
```
61e6efbb-0051-42f2-bfbe-9f0cd5eab853           1285
61e6efbb-0051-42f2-bfbe-9f0cd5eab853.Thumb      948
9978ccba-8b98-4d7c-942d-88667845331f         338949
9978ccba-8b98-4d7c-942d-88667845331f.Thumb    35073
b0dcb044-a636-4500-b6e3-0c4b0213d030          62970
b0dcb044-a636-4500-b6e3-0c4b0213d030.Thumb    15411
e5957556-c342-43b6-b808-192c68247ae7          71655
e5957556-c342-43b6-b808-192c68247ae7.Thumb     7452

```