### PR TITLE
Fix "Name Change Script" from context menu nulling username in game files

### DIFF
--- a/LANCommander.Launcher.Data/Models/User.cs
+++ b/LANCommander.Launcher.Data/Models/User.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace LANCommander.Launcher.Data.Models;
 
@@ -9,4 +10,8 @@ public class User : BaseModel
     public string? Alias { get; set; }
     public Media? Avatar { get; set; }
     public Library? Library { get; set; }
+
+    [JsonIgnore]
+    [NotMapped]
+    public string? GetUserNameSafe => Alias ?? UserName;
 }

--- a/LANCommander.Launcher.Models/Settings.cs
+++ b/LANCommander.Launcher.Models/Settings.cs
@@ -7,6 +7,8 @@ namespace LANCommander.Launcher.Models
 {
     public class Settings
     {
+        public const string DEFAULT_GAME_USERNAME = "Player";
+
         public int LaunchCount { get; set; } = 0;
 
         public DatabaseSettings Database { get; set; } = new DatabaseSettings();

--- a/LANCommander.Launcher.Services/CommandLineService.cs
+++ b/LANCommander.Launcher.Services/CommandLineService.cs
@@ -93,7 +93,7 @@ namespace LANCommander.Launcher.Services
                     break;
 
                 case SDK.Enums.ScriptType.NameChange:
-                    await Client.Scripts.RunNameChangeScriptAsync(options.InstallDirectory, options.GameId, options.NewPlayerAlias);
+                    await Client.Scripts.RunNameChangeScriptAsync(options.InstallDirectory, options.GameId, options.NewPlayerAlias ?? Settings.DEFAULT_GAME_USERNAME);
                     break;
 
                 case SDK.Enums.ScriptType.KeyChange:

--- a/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
@@ -269,7 +269,7 @@ else
 
         foreach (var manifest in manifests)
         {
-            await Client.Scripts.RunNameChangeScriptAsync(Game.InstallDirectory, Game.Id, user.Alias);
+            await Client.Scripts.RunNameChangeScriptAsync(Game.InstallDirectory, Game.Id, user.GetUserNameSafe ?? Settings.DEFAULT_GAME_USERNAME);
         }
     }
 

--- a/LANCommander.Launcher/UI/Components/ProfileButton.razor
+++ b/LANCommander.Launcher/UI/Components/ProfileButton.razor
@@ -43,7 +43,7 @@
 
     User User;
     Guid AvatarId = Guid.Empty;
-    string Alias = "Player";
+    string Alias = Settings.DEFAULT_GAME_USERNAME;
 
     protected override async Task OnInitializedAsync()
     {
@@ -52,7 +52,7 @@
             User = await UserService.GetCurrentUser();
 
             AvatarId = User?.Avatar?.Id ?? Guid.Empty;
-            Alias = String.IsNullOrWhiteSpace(User?.Alias) ? User?.UserName ?? "Player" : User.Alias;
+            Alias = String.IsNullOrWhiteSpace(User?.Alias) ? User?.UserName ?? Settings.DEFAULT_GAME_USERNAME : User.Alias;
         };
         
         await ProfileService.DownloadProfileInfoAsync();


### PR DESCRIPTION
Fixes "Name Change Script" from context menu eventually nulling username in game files

Issue:
- Script is passed a null object in `$NewPlayerAlias`
- NameChange-Script is callled with `Alias` as parameter, which is _NULL_ on default installations

Changes:
- Falls back to username on calling the script
- Adds GetUserName getter property to `Launcher.Data/Models` _User_ model to return `Alias` which fallbacks to `UserName` (still nullable)
- Defines constant [Launcher] settings `DEFAULT_GAME_USERNAME` to "Player" constant used on several cases

![NameChangeScript-Error](https://github.com/user-attachments/assets/2dfcb127-f0b3-4dbe-95b7-b856282ab8d3)
