### PR TITLE
Utilizing MadMilkman.INI for ini parsing

### DIFF
--- a/LANCommander.SDK.Tests/IniHandling/ConfigurationTest.cs
+++ b/LANCommander.SDK.Tests/IniHandling/ConfigurationTest.cs
@@ -1,0 +1,73 @@
+﻿using MadMilkman.Ini;
+
+namespace LANCommander.SDK.Tests.IniHandling
+{
+    using SectionKey = KeyValuePair<string, IList<string>>;
+
+    public class ConfigurationTest
+    {
+        public required string Ini { get; set; } 
+
+        public IList<string> RequiredSections { get; set; } = [];
+        public IList<KeyValuePair<string, int>> RequiredSectionsCount { get; set; } = [];
+
+
+        public IList<SectionKey> RequiredKeys { get; set; } = [];
+        public IList<KeyValuePair<string, IList<KeyValuePair<string, int>>>> RequiredKeysCount { get; set; } = [];
+
+        public IList<SectionKeyValue> RequiredKeyValues { get; set; } = [];
+
+        public IList<UpdateSectionKeyValue> UpdateKeyValues { get; set; } = [];
+
+
+        public class SectionKeyValue(string section)
+        {
+            public class KeyValue
+            {
+                public string Key { get; set; }
+                public string? Value { get; set; }
+                public IList<string>? Values { get; set; }
+
+                public KeyValue(string key, string? value)
+                {
+                    Key = key;
+                    Value = value;
+                }
+
+                public KeyValue(string key, IList<string>? values)
+                {
+                    Key = key;
+                    Values = values;
+                }
+            }
+
+            public string Section { get; set; } = section;
+            public IniOptions? Options { get; set; }
+
+            public SectionKeyValue(string section, IniOptions options) : this(section) => Options = options;
+
+            public IList<KeyValue> KeyValues { get; set; } = [];
+        }
+
+        public class UpdateSectionKeyValue(string section)
+        {
+            public class UpdateKeyValue
+            {
+                public required string Key { get; set; }
+                public string? OldValue { get; set; }
+                public string? NewValue { get; set; }
+
+                public IList<string>? ExpectedValues { get; set; }
+            }
+
+            public string Section { get; set; } = section;
+            public IniOptions? Options { get; set; }
+
+            public UpdateSectionKeyValue(string section, IniOptions options) : this(section) => Options = options;
+
+            public IList<UpdateKeyValue> UpdateKeyValues { get; set; } = [];
+            public IList<SectionKeyValue> CheckKeyValues { get; set; } = [];
+        }
+
+    }
+}

--- a/LANCommander.SDK.Tests/IniHandling/ConfigurationTests.cs
+++ b/LANCommander.SDK.Tests/IniHandling/ConfigurationTests.cs
@@ -1,0 +1,240 @@
+﻿using MadMilkman.Ini;
+
+namespace LANCommander.SDK.Tests.IniHandling
+{
+    using KeyValueInt = KeyValuePair<string, int>;
+    using SectionKey = KeyValuePair<string, IList<string>>;
+
+    public static class ConfigurationTests
+    {
+        public static ConfigurationTest Test_SingleSection = new ConfigurationTest
+        {
+            Ini = @"; last modified 1 April 2001 by John Doe
+[owner]
+name = John Doe
+organization = Acme Widgets Inc.",
+
+            RequiredSections = { "owner" },
+            RequiredKeys =
+            {
+                new SectionKey("owner", ["name", "organization"]),
+            },
+            RequiredKeyValues =
+            {
+                new ConfigurationTest.SectionKeyValue("owner")
+                {
+                    KeyValues = [
+                        new ConfigurationTest.SectionKeyValue.KeyValue("name", "John Doe"),
+                        new ConfigurationTest.SectionKeyValue.KeyValue("organization", "Acme Widgets Inc."),
+                    ],
+                },
+            }
+        };
+
+        public static ConfigurationTest Test_TwoSections = new ConfigurationTest
+        {
+            Ini = @"[person1]
+name=Mikey
+age=4
+
+[person2]
+name=Becky
+age=46",
+
+            RequiredSections = { "person1", "person2" },
+            RequiredKeys =
+            {
+                new SectionKey("person1", ["name", "age"]),
+                new SectionKey("person2", ["name", "age"]),
+            },
+            RequiredKeyValues =
+            {
+                new ConfigurationTest.SectionKeyValue("person1")
+                {
+                    KeyValues = [
+                        new ConfigurationTest.SectionKeyValue.KeyValue("name", "Mikey"),
+                        new ConfigurationTest.SectionKeyValue.KeyValue("age", "4"),
+                    ],
+                },
+                new ConfigurationTest.SectionKeyValue("person2")
+                {
+                    KeyValues = [
+                        new ConfigurationTest.SectionKeyValue.KeyValue("name", "Becky"),
+                        new ConfigurationTest.SectionKeyValue.KeyValue("age", "46"),
+                    ],
+                },
+            }
+        };
+
+        public static ConfigurationTest Test_ArrayStatic = new ConfigurationTest
+        {
+            Ini = @"[Engine.Input]
+Aliases[0]=(Command=""Button bFire | Fire"",Alias=Fire)
+Aliases[1]=(Command=""Button bAltFire | AltFire"",Alias=AltFire)
+Aliases[2]=(Command=""Axis aBaseY  Speed=+300.0"",Alias=MoveForward)
+0=SwitchWeapon 0
+1=SwitchWeapon 1
+2=SwitchWeapon 2
+3=SwitchWeapon 3
+"
+,
+
+            RequiredSections = { "Engine.Input" },
+            RequiredKeys =
+            {
+                new SectionKey("Engine.Input", ["Aliases[0]", "Aliases[1]", "0", "1", "2", "3"]),
+            },
+            RequiredKeysCount =
+            {
+                new KeyValuePair<string, IList<KeyValueInt>>("Engine.Input", [
+                    new KeyValueInt("", 7)
+                ]),
+            },
+            RequiredKeyValues =
+            {
+                new ConfigurationTest.SectionKeyValue("Engine.Input")
+                {
+                    KeyValues = [
+                        new ConfigurationTest.SectionKeyValue.KeyValue("Aliases[0]", "(Command=\"Button bFire | Fire\",Alias=Fire)"),
+                        new ConfigurationTest.SectionKeyValue.KeyValue("0", "SwitchWeapon 0"),
+                    ],
+                },
+            },
+
+            UpdateKeyValues =
+            {
+                new ConfigurationTest.UpdateSectionKeyValue("Engine.Input")
+                {
+                    UpdateKeyValues = [
+                        new ConfigurationTest.UpdateSectionKeyValue.UpdateKeyValue { Key = "Aliases[0]", NewValue = "(Command=\"Button bAltFire | AltFire\",Alias=AltFire)" },
+                        new ConfigurationTest.UpdateSectionKeyValue.UpdateKeyValue { Key = "Aliases[1]", NewValue = "(Command=\"Button bFire | Fire\",Alias=Fire)" },
+                    ],
+                    CheckKeyValues = [
+                        new ConfigurationTest.SectionKeyValue("Engine.Input")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Aliases[0]", "(Command=\"Button bAltFire | AltFire\",Alias=AltFire)"),
+                            ],
+                        },
+                    ],
+                },
+            }
+        };
+
+        public static ConfigurationTest Test_ArrayMultiValue = new ConfigurationTest
+        {
+            Ini = @"[Startup]
+Package=Core
+Package=Engine
+
+[User]
+Name=Player
+Team=1
+"
+,
+
+            RequiredSections = { "Startup" },
+            RequiredKeys =
+            {
+                new SectionKey("Startup", ["Package"]),
+            },
+            RequiredKeysCount =
+            {
+                new KeyValuePair<string, IList<KeyValueInt>>("Startup", [
+                    new KeyValueInt("Package", 2)
+                ]),
+            },
+            RequiredKeyValues =
+            {
+                new ConfigurationTest.SectionKeyValue("Startup")
+                {
+                    KeyValues = [
+                        new ConfigurationTest.SectionKeyValue.KeyValue("Package", "Core"),
+                        new ConfigurationTest.SectionKeyValue.KeyValue("Package", "Engine"),
+                    ],
+                },
+            },
+
+            UpdateKeyValues =
+            {
+                new ConfigurationTest.UpdateSectionKeyValue("User")
+                {
+                    UpdateKeyValues = [new ConfigurationTest.UpdateSectionKeyValue.UpdateKeyValue { Key = "Name", NewValue = "Admin" }],
+                    CheckKeyValues = [
+                        new ConfigurationTest.SectionKeyValue("Startup")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Package", ["Core", "Engine"]),
+                            ],
+                        },
+                        new ConfigurationTest.SectionKeyValue("User")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Name", "Admin"),
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Team", "1"),
+                            ],
+                        },
+                    ],
+                },
+
+                new ConfigurationTest.UpdateSectionKeyValue("Startup")
+                {
+                    Options = new IniOptions
+                    {
+                        KeyDuplicate = IniDuplication.Ignored, // merges, takes first value of a multi-value key
+                    },
+                    UpdateKeyValues = [
+                        new ConfigurationTest.UpdateSectionKeyValue.UpdateKeyValue {
+                            Key = "Package",
+                            NewValue = "UI",
+                            ExpectedValues = ["UI"],
+                        },
+                    ],
+                    CheckKeyValues = [
+                        new ConfigurationTest.SectionKeyValue("Startup")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Package", "UI"),
+                            ],
+                        },
+                        new ConfigurationTest.SectionKeyValue("User")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Name", "Player"),
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Team", "1"),
+                            ],
+                        },
+                    ],
+                },
+
+                new ConfigurationTest.UpdateSectionKeyValue("Startup")
+                {
+                    Options = new IniOptions
+                    {
+                        KeyDuplicate = IniDuplication.Allowed, // keep multi-value keys
+                    },
+                    UpdateKeyValues = [new ConfigurationTest.UpdateSectionKeyValue.UpdateKeyValue {
+                        Key = "Package",
+                        NewValue = "UI",
+                        ExpectedValues = ["Core", "UI"],
+                    }],
+                    CheckKeyValues = [
+                        new ConfigurationTest.SectionKeyValue("Startup")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Package", ["Core", "UI"]),
+                            ],
+                        },
+                        new ConfigurationTest.SectionKeyValue("User")
+                        {
+                            KeyValues = [
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Name", "Player"),
+                                new ConfigurationTest.SectionKeyValue.KeyValue("Team", "1"),
+                            ],
+                        },
+                    ],
+                },
+            }
+        };
+    }
+}

--- a/LANCommander.SDK.Tests/IniHandling/IniHandlingTests_MadMilkman.cs
+++ b/LANCommander.SDK.Tests/IniHandling/IniHandlingTests_MadMilkman.cs
@@ -1,0 +1,256 @@
+﻿using System.Reflection;
+using System.Text;
+using LANCommander.SDK.Helpers;
+
+namespace LANCommander.SDK.Tests.IniHandling
+{
+    public class IniHandlingTests_MadMilkman
+    {
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void Parse(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+            Assert.NotNull(ini);
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSections(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+
+            foreach (var requiredKey in configuration.RequiredSections)
+            {
+                Assert.True(ini.Sections.Contains(requiredKey));
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionsCount(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredSectionsCount)
+            {
+                Assert.Equal(requiredSection.Value, ini.Sections.Count(x => string.Equals(x.Name, requiredSection.Key, StringComparison.InvariantCultureIgnoreCase)));
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeys(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeys)
+            {
+                var section = ini.Sections[requiredSection.Key];
+                Assert.NotNull(section);
+
+                foreach (var requiredKey in requiredSection.Value)
+                {
+                    Assert.True(section.Keys.Contains(requiredKey));
+                }
+            }
+        }
+
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeysCount(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeysCount)
+            {
+                var section = ini.Sections[requiredSection.Key];
+                Assert.NotNull(section);
+
+                foreach (var requiredKeys in requiredSection.Value)
+                {
+                    var count = (requiredKeys.Key == "")
+                        ? section.Keys.Count
+                        : section.Keys.Count(x => string.Equals(x.Name, requiredKeys.Key, StringComparison.InvariantCultureIgnoreCase));
+
+                    Assert.Equal(requiredKeys.Value, count);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeyValues(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeyValues)
+            {
+                var section = ini.Sections[requiredSection.Section];
+                Assert.NotNull(section);
+
+                foreach (var requiredKeyValue in requiredSection.KeyValues)
+                {
+                    var match = section.Keys.FirstOrDefault(key => {
+                        return string.Equals(key.Name, requiredKeyValue.Key, StringComparison.InvariantCultureIgnoreCase)
+                            && string.Equals(key.Value, requiredKeyValue.Value, StringComparison.InvariantCulture);
+                    });
+
+                    Assert.NotNull(match);
+                }
+            }
+        }
+
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void UpdateSectionKeyValues(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = IniHelper.FromString(configuration.Ini);
+            Assert.NotNull(ini);
+
+            foreach (var requiredSection in configuration.UpdateKeyValues)
+            {
+                var options = requiredSection.Options ?? IniHelper.DefaultIniOptions;
+                ini = IniHelper.FromString(configuration.Ini, options);
+                var section = ini.Sections[requiredSection.Section];
+                Assert.NotNull(section);
+
+                foreach (var updateKeyValue in requiredSection.UpdateKeyValues)
+                {
+                    bool found = false;
+
+                    foreach (var iniKey in section.Keys.Reverse())
+                    {
+                        if (string.Equals(iniKey.Name, updateKeyValue.Key, StringComparison.InvariantCultureIgnoreCase))
+                        {
+                            if (updateKeyValue.OldValue == null || string.Equals(updateKeyValue.Key, iniKey.Value, StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                iniKey.Value = updateKeyValue.NewValue;
+                                Assert.Equal(iniKey.Value, updateKeyValue.NewValue);
+                                found = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    Assert.True(found);
+                }
+
+                // check if values are stored properly
+
+                foreach (var requiredKeyValue in requiredSection.UpdateKeyValues)
+                {
+                    IList<KeyValuePair<string, string?>> searches = [];
+                    searches.Add(new KeyValuePair<string, string?>(requiredKeyValue.Key, requiredKeyValue.NewValue));
+
+                    if (requiredKeyValue.ExpectedValues != null)
+                    {
+                        foreach (var expected in requiredKeyValue.ExpectedValues)
+                        {
+                            searches.Add(new KeyValuePair<string, string?>(requiredKeyValue.Key, expected));
+                        }
+                    }
+
+                    foreach (var search in searches)
+                    {
+                        var match = section.Keys.FirstOrDefault(key =>
+                        {
+                            return string.Equals(key.Name, requiredKeyValue.Key, StringComparison.InvariantCultureIgnoreCase)
+                                && string.Equals(key.Value, requiredKeyValue.NewValue, StringComparison.InvariantCulture);
+                        });
+
+                        Assert.NotNull(match);
+                    }
+                }
+
+                // compare newly generated INI
+
+                string iniContentNew = IniHelper.ToString(ini, Encoding.Default);
+                var iniNew = IniHelper.FromString(iniContentNew, options);
+                Assert.NotNull(iniNew);
+
+                foreach (var checkSection in requiredSection.CheckKeyValues)
+                {
+                    var sectionNew = iniNew.Sections[checkSection.Section];
+                    Assert.NotNull(sectionNew);
+
+                    foreach (var checkKeyValue in checkSection.KeyValues)
+                    {
+                        IList<KeyValuePair<string, string?>> searches = [];
+                        if (checkKeyValue.Values != null)
+                        {
+                            foreach (var expected in checkKeyValue.Values)
+                            {
+                                searches.Add(new KeyValuePair<string, string?>(checkKeyValue.Key, expected));
+                            }
+                        }
+                        else
+                        {
+                            searches.Add(new KeyValuePair<string, string?>(checkKeyValue.Key, checkKeyValue.Value));
+                        }
+
+                        foreach (var search in searches)
+                        {
+                            var match = sectionNew.Keys.FirstOrDefault(key =>
+                            {
+                                return string.Equals(key.Name, search.Key, StringComparison.InvariantCultureIgnoreCase)
+                                    && string.Equals(key.Value, search.Value, StringComparison.InvariantCulture);
+                            });
+
+                            Assert.NotNull(match);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static ConfigurationTest GetConfiguration(string configurationName)
+        {
+            Type configTestsType = typeof(ConfigurationTests);
+            FieldInfo? field = configTestsType?.GetField(configurationName, BindingFlags.Public | BindingFlags.Static);
+
+            if (field == null)
+            {
+                throw new Exception($"The configuration '{configurationName}' does not exist.");
+            }
+
+            ConfigurationTest? configurationTest = field.GetValue(null) as ConfigurationTest;
+            if (configurationTest == null)
+            {
+                throw new Exception($"The configuration '{configurationName}' is not of type ConfigurationTest or is null.");
+            }
+
+            return configurationTest;
+        }
+    }
+}

--- a/LANCommander.SDK.Tests/IniHandling/IniHandlingTests_PeanutButter.cs
+++ b/LANCommander.SDK.Tests/IniHandling/IniHandlingTests_PeanutButter.cs
@@ -1,0 +1,207 @@
+﻿using System.Reflection;
+using PeanutButter.INI;
+
+namespace LANCommander.SDK.Tests.IniHandling
+{
+    public class IniHandlingTests_PeanutButter
+    {
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void Parse(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+            Assert.NotNull(ini);
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSections(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+
+            foreach (var requiredKey in configuration.RequiredSections)
+            {
+                Assert.True(ini.HasSection(requiredKey));
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionsCount(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredSectionsCount)
+            {
+                Assert.Equal(requiredSection.Value, ini.AllSections.Count(x => string.Equals(x, requiredSection.Key, StringComparison.InvariantCultureIgnoreCase)));
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeys(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeys)
+            {
+                var section = ini.GetSection(requiredSection.Key);
+                Assert.NotNull(section);
+
+                foreach (var requiredKey in requiredSection.Value)
+                {
+                    Assert.True(section.ContainsKey(requiredKey));
+                }
+            }
+        }
+
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeysCount(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeysCount)
+            {
+                var section = ini.GetSection(requiredSection.Key);
+                Assert.NotNull(section);
+
+                foreach (var requiredKeys in requiredSection.Value)
+                {
+                    Assert.Equal(requiredKeys.Value, section.Keys.Count(x => string.Equals(x, requiredKeys.Key, StringComparison.InvariantCultureIgnoreCase)));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        [InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void CheckSectionKeyValues(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+
+            foreach (var requiredSection in configuration.RequiredKeyValues)
+            {
+                var section = ini.GetSection(requiredSection.Section);
+                Assert.NotNull(section);
+
+                foreach (var requiredKeyValue in requiredSection.KeyValues)
+                {
+                    var match = section.FirstOrDefault(key => 
+                    {
+                        return string.Equals(key.Key, requiredKeyValue.Key, StringComparison.InvariantCultureIgnoreCase)
+                            && string.Equals(key.Value, requiredKeyValue.Value, StringComparison.InvariantCulture);
+                    });
+
+                    Assert.NotEqual(match, default);
+                }
+            }
+        }
+
+        [Theory]
+        //[InlineData(nameof(ConfigurationTests.Test_SingleSection))]
+        //[InlineData(nameof(ConfigurationTests.Test_TwoSections))]
+        //[InlineData(nameof(ConfigurationTests.Test_ArrayStatic))]
+        [InlineData(nameof(ConfigurationTests.Test_ArrayMultiValue))]
+        public void UpdateSectionKeyValues(string configurationName)
+        {
+            ConfigurationTest configuration = GetConfiguration(configurationName);
+            var ini = INIFile.FromString(configuration.Ini);
+            Assert.NotNull(ini);
+
+            foreach (var requiredSection in configuration.UpdateKeyValues)
+            {
+                var section = ini.GetSection(requiredSection.Section);
+                Assert.NotNull(section);
+
+                foreach (var updateKeyValue in requiredSection.UpdateKeyValues)
+                {
+                    ini.SetValue(requiredSection.Section, updateKeyValue.Key, updateKeyValue.NewValue);
+                    var value = ini.GetValue(requiredSection.Section, updateKeyValue.Key);
+                    Assert.True(updateKeyValue.NewValue == null || string.Equals(updateKeyValue.NewValue, value, StringComparison.InvariantCulture));
+                }
+
+                // compare newly generated INI
+                string iniContentNew = ini.ToString();
+                var iniNew = INIFile.FromString(iniContentNew);
+                Assert.NotNull(iniNew);
+
+                foreach (var checkSection in requiredSection.CheckKeyValues)
+                {
+                    var sectionNew = iniNew.GetSection(checkSection.Section);
+                    Assert.NotNull(sectionNew);
+
+                    foreach (var checkKeyValue in checkSection.KeyValues)
+                    {
+                        IList<KeyValuePair<string, string?>> searches = [];
+                        if (checkKeyValue.Values != null)
+                        {
+                            foreach (var expected in checkKeyValue.Values)
+                            {
+                                searches.Add(new KeyValuePair<string, string?>(checkKeyValue.Key, expected));
+                            }
+                        }
+                        else
+                        {
+                            searches.Add(new KeyValuePair<string, string?>(checkKeyValue.Key, checkKeyValue.Value));
+                        }
+
+                        foreach (var search in searches)
+                        {
+                            var match = section.FirstOrDefault(key =>
+                            {
+                                return string.Equals(key.Key, search.Key, StringComparison.InvariantCultureIgnoreCase)
+                                    && string.Equals(key.Value, search.Value, StringComparison.InvariantCulture);
+                            });
+
+                            Assert.NotEqual(match, default);
+                        }
+                    }
+                }
+            }
+        }
+
+        public static ConfigurationTest GetConfiguration(string configurationName)
+        {
+            Type configTestsType = typeof(ConfigurationTests);
+            FieldInfo? field = configTestsType?.GetField(configurationName, BindingFlags.Public | BindingFlags.Static);
+
+            if (field == null)
+            {
+                throw new Exception($"The configuration '{configurationName}' does not exist.");
+            }
+
+            ConfigurationTest? configurationTest = field.GetValue(null) as ConfigurationTest;
+            if (configurationTest == null)
+            {
+                throw new Exception($"The configuration '{configurationName}' is not of type ConfigurationTest or is null.");
+            }
+
+            return configurationTest;
+        }
+    }
+}

--- a/LANCommander.SDK/Helpers/IniHelper.cs
+++ b/LANCommander.SDK/Helpers/IniHelper.cs
@@ -1,0 +1,49 @@
+﻿using System.IO;
+using System.Text;
+using MadMilkman.Ini;
+
+namespace LANCommander.SDK.Helpers
+{
+    public static class IniHelper
+    {
+        public static readonly IniOptions DefaultIniOptions = new()
+        {
+        };
+
+        public static IniFile FromString(string iniFileContent)
+        {
+            return FromString(iniFileContent, DefaultIniOptions);
+        }
+
+        public static IniFile FromString(string iniFileContent, IniOptions options)
+        {
+            IniFile file = new(options);
+
+            using (var stream = new MemoryStream(options.Encoding.GetBytes(iniFileContent)))
+                file.Load(stream);
+
+            return file;
+        }
+
+        public static string ToString(IniFile file, IniOptions options)
+        {
+            return ToString(file, options.Encoding);
+        }
+
+        public static string ToString(IniFile file, Encoding encoding)
+        {
+            string iniFileContent;
+            using (var stream = new MemoryStream())
+            using (var reader = new StreamReader(stream, encoding))
+            {
+                file.Save(stream);
+                stream.Flush();
+                stream.Seek(0, SeekOrigin.Begin);
+
+                iniFileContent = reader.ReadToEnd();
+            }
+
+            return iniFileContent;
+        }
+    }
+}

--- a/LANCommander.SDK/LANCommander.SDK.csproj
+++ b/LANCommander.SDK/LANCommander.SDK.csproj
@@ -19,6 +19,7 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Crc32.NET" Version="1.2.0" />
         <PackageReference Include="Facepunch.Steamworks" Version="2.3.3" />
+        <PackageReference Include="MadMilkman.Ini" Version="1.0.6" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
         <PackageReference Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.4.7" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.4.7" />

--- a/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
+++ b/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
@@ -62,10 +62,24 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
         [Alias("keepkey", "keydup")]
         [Parameter(Mandatory = false)]
         public bool KeepKeyDuplicates { get; set; } = true;
+        [Alias("nokey", "nokeydup")]
+        [Parameter(Mandatory = false)]
+        public SwitchParameter NoKeyDuplicates
+        {
+            get => new(!KeepKeyDuplicates);
+            set => KeepKeyDuplicates = !value.ToBool();
+        }
 
         [Alias("keepsec", "secdup")]
         [Parameter(Mandatory = false)]
         public bool KeepSectionDuplicates { get; set; } = true;
+        [Alias("nosec", "nosecdup")]
+        [Parameter(Mandatory = false)]
+        public SwitchParameter NoSectionDuplicates 
+        {
+            get => new(!KeepSectionDuplicates);
+            set => KeepSectionDuplicates = !value.ToBool();
+        }
 
         [Alias("encoding", "enc")]
         [Parameter(Mandatory = false)]

--- a/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
+++ b/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
@@ -1,7 +1,11 @@
-﻿using PeanutButter.INI;
+﻿using MadMilkman.Ini;
+using PeanutButter.INI;
 using System;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
+using System.Text;
+using YamlDotNet.Core.Tokens;
 
 namespace LANCommander.SDK.PowerShell.Cmdlets
 {
@@ -10,30 +14,127 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
     public class UpdateIniValueCmdlet : Cmdlet
     {
         [Parameter(Mandatory = true, Position = 0)]
+        [Alias("s")]
         public string Section { get; set; }
 
         [Parameter(Mandatory = true, Position = 1)]
+        [Alias("k")]
         public string Key { get; set; }
 
         [Parameter(Mandatory = true, Position = 2)]
+        [Alias("v")]
         public string Value { get; set; }
 
         [Parameter(Mandatory = true, Position = 3)]
+        [Alias("f")]
         public string FilePath { get; set; }
 
         [Parameter(Mandatory = false)]
+        [Alias("wrap", "quotes")]
         public bool WrapValueInQuotes { get; set; } = false;
+
+        [Parameter(Mandatory = false)]
+        [Alias("add")]
+        public bool UpdateOrAdd { get; set; } = true;
+
+        [Alias("remove-only")]
+        [Parameter(Mandatory = false)]
+        public SwitchParameter OnlyRemove { get; set; } = false;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Clear { get; set; } = false;
+
+        [Alias("append")]
+        [Parameter(Mandatory = false)]
+        public SwitchParameter AlwaysAppend { get; set; } = false;
+
+        [Parameter(Mandatory = false)]
+        [Alias("insert")]
+        public int? InsertIndex { get; set; } = null;
+
+        [Alias("keepkey", "keydup")]
+        [Parameter(Mandatory = false)]
+        public bool KeepKeyDuplicates { get; set; } = true;
+
+        [Alias("keepsec", "secdup")]
+        [Parameter(Mandatory = false)]
+        public bool KeepSectionDuplicates { get; set; } = true;
+
+        [Alias("encoding", "enc")]
+        [Parameter(Mandatory = false)]
+        public string Codepage { get; set; } = "Latin";
+
+        protected Encoding GetEncoding()
+        {
+            string page = Codepage?.ToLower();
+            switch (page)
+            {
+                case "uft8": return Encoding.UTF8;
+                case "latin":
+                case "latin1":
+                case "ISO-8859-1":
+                    return Encoding.Latin1;
+                case "asci":
+                case "ascii":
+                    return Encoding.ASCII;
+                case "unicode":
+                    return Encoding.Unicode;
+            }
+
+            return Encoding.Default;
+        }
 
         protected override void ProcessRecord()
         {
-            if (File.Exists(FilePath))
-            {
-                var ini = new INIFile(FilePath);
+            if (!File.Exists(FilePath))
+                return;
 
-                ini.SetValue(Section, Key, Value);
-                ini.WrapValueInQuotes = WrapValueInQuotes;
-                ini.Persist();
+            var iniOptions = new IniOptions()
+            {
+                Encoding = GetEncoding(),
+                SectionDuplicate = KeepSectionDuplicates ? IniDuplication.Allowed : IniDuplication.Ignored,
+                KeyDuplicate = KeepKeyDuplicates ? IniDuplication.Allowed : IniDuplication.Ignored,
+            };
+            var ini = new IniFile(iniOptions);
+            ini.Load(FilePath);
+
+            var iniSection = ini.Sections[Section];
+            if (iniSection == null)
+                return;
+
+            bool keyMatcher(IniKey x) => string.Equals(x.Name, Key, StringComparison.OrdinalIgnoreCase);
+
+            if (OnlyRemove || Clear)
+            {
+                var list = iniSection.Keys.Where(keyMatcher).ToList();
+                list.ForEach(x => iniSection.Keys.Remove(x));
             }
+
+            if (!OnlyRemove)
+            {
+                // assuming most of the engines interpret INI files from top to bottom using the last value of a multiple existing key, we update the last found key
+                var firstMatch = iniSection.Keys.LastOrDefault(keyMatcher);
+                if (AlwaysAppend.ToBool() || (UpdateOrAdd && firstMatch == null))
+                {
+                    if (InsertIndex.HasValue && InsertIndex.Value >= 0)
+                        iniSection.Keys.Insert(Math.Clamp(InsertIndex.Value, 0, iniSection.Keys.Count - 1), Key, Value);
+                    else
+                        iniSection.Keys.Add(Key, Value);
+                }
+                else if (firstMatch != null)
+                {
+                    var insertIndex = (InsertIndex.HasValue && InsertIndex.Value >= 0) ? Math.Clamp(InsertIndex.Value, 0, iniSection.Keys.Count - 1)  : -1;
+                    if (insertIndex >= 0)
+                    {
+                        iniSection.Keys.Remove(firstMatch);
+                        iniSection.Keys.Insert(insertIndex, firstMatch);
+                    }
+                    firstMatch.Value = Value;
+                }
+                // no else, as it should be possible to only update an existing value without adding a new one
+            }
+
+            ini.Save(FilePath);
         }
     }
 }

--- a/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
+++ b/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
@@ -1,99 +1,161 @@
 ﻿using MadMilkman.Ini;
-using PeanutButter.INI;
 using System;
 using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Text;
-using YamlDotNet.Core.Tokens;
 
 namespace LANCommander.SDK.PowerShell.Cmdlets
 {
+    /// <summary>
+    /// Cmdlet for updating an INI file value. This cmdlet updates, adds, or removes a key-value pair within a specified section 
+    /// of an INI file, based on provided parameters.
+    /// </summary>
     [Cmdlet(VerbsData.Update, "IniValue")]
     [OutputType(typeof(string))]
     public class UpdateIniValueCmdlet : Cmdlet
     {
-        [Parameter(Mandatory = true, Position = 0)]
+        /// <summary>
+        /// Gets or sets the section in the INI file that contains the key to be updated.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 0, HelpMessage = "Specifies the section in the INI file that contains the key to be updated.")]
         [Alias("s")]
         public string Section { get; set; }
 
-        [Parameter(Mandatory = true, Position = 1)]
+        /// <summary>
+        /// Gets or sets the key within the section whose value should be updated.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 1, HelpMessage = "Specifies the key within the section whose value should be updated.")]
         [Alias("k")]
         public string Key { get; set; }
 
-        [Parameter(Mandatory = true, Position = 2)]
+        /// <summary>
+        /// Gets or sets the new value to assign to the provided key.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 2, HelpMessage = "Specifies the new value to assign to the provided key.")]
         [Alias("v")]
         public string Value { get; set; }
 
-        [Parameter(Mandatory = true, Position = 3)]
+        /// <summary>
+        /// Gets or sets the full file path to the INI file that should be processed.
+        /// </summary>
+        [Parameter(Mandatory = true, Position = 3, HelpMessage = "Specifies the file path to the INI file that should be processed.")]
         [Alias("f")]
         public string FilePath { get; set; }
 
-        [Parameter(Mandatory = false)]
+        /// <summary>
+        /// Gets or sets a value indicating whether the value should be wrapped in quotes.
+        /// Useful for handling special characters.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "If set, the value will be wrapped in quotes. Useful to handle special characters.")]
         [Alias("wrap", "quotes")]
         public bool WrapValueInQuotes { get; set; } = false;
 
-        [Parameter(Mandatory = false)]
+        /// <summary>
+        /// Gets or sets a switch parameter that updates an existing key or adds a new one if it does not exist.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "If set, the cmdlet will update an existing key or add a new one if it does not exist.")]
         [Alias("add")]
         public SwitchParameter UpdateOrAdd { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a switch parameter that restricts the operation to updating existing keys only; no new key will be added.
+        /// </summary>
         [Alias("update-only", "only-update")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If set, restricts the operation to updating existing keys only; no new key will be added.")]
         public SwitchParameter NoAdd
         {
             get => new(!UpdateOrAdd);
             set => UpdateOrAdd = !value.ToBool();
         }
 
+        /// <summary>
+        /// Gets or sets a switch parameter that specifies the key(s) will only be removed from the section without updating or adding any value.
+        /// </summary>
         [Alias("remove-only")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If set, the key(s) will only be removed from the section without updating or adding any value.")]
         public SwitchParameter OnlyRemove { get; set; } = false;
 
-        [Parameter(Mandatory = false)]
+        /// <summary>
+        /// Gets or sets a switch parameter that clears all instances of the specified key in the section.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "If set, all instances of the specified key in the section will be cleared.")]
         public SwitchParameter Clear { get; set; } = false;
 
+        /// <summary>
+        /// Gets or sets a switch parameter that specifies a new key-value pair will always be appended, 
+        /// even if the key already exists.
+        /// </summary>
         [Alias("append")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If set, a new key-value pair will always be appended, even if the key already exists.")]
         public SwitchParameter AlwaysAppend { get; set; } = false;
 
-        [Parameter(Mandatory = false)]
+        /// <summary>
+        /// Gets or sets the index position at which the new key-value pair should be inserted.
+        /// If not provided, the key is added at the end.
+        /// </summary>
+        [Parameter(Mandatory = false, HelpMessage = "Specifies the index position at which the new key-value pair should be inserted. If not provided, the key is added at the end.")]
         [Alias("insert")]
         public int? InsertIndex { get; set; } = null;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether duplicate keys are allowed within the section.
+        /// </summary>
         [Alias("keepkey", "keydup")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If true, duplicate keys are allowed within the section.")]
         public bool KeepKeyDuplicates { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a switch parameter that prevents duplicate keys in the section.
+        /// </summary>
         [Alias("nokey", "nokeydup")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If set, duplicate keys in the section are prevented.")]
         public SwitchParameter NoKeyDuplicates
         {
             get => new(!KeepKeyDuplicates);
             set => KeepKeyDuplicates = !value.ToBool();
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether duplicate sections in the INI file are allowed.
+        /// </summary>
         [Alias("keepsec", "secdup")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "If true, duplicate sections in the INI file are allowed.")]
         public bool KeepSectionDuplicates { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a switch parameter that prevents duplicate section names in the INI file.
+        /// </summary>
         [Alias("nosec", "nosecdup")]
-        [Parameter(Mandatory = false)]
-        public SwitchParameter NoSectionDuplicates 
+        [Parameter(Mandatory = false, HelpMessage = "If set, duplicate section names are not permitted in the INI file.")]
+        public SwitchParameter NoSectionDuplicates
         {
             get => new(!KeepSectionDuplicates);
             set => KeepSectionDuplicates = !value.ToBool();
         }
 
+        /// <summary>
+        /// Gets or sets the encoding (codepage) for reading and writing the INI file.
+        /// Examples include 'UTF8', 'Latin', 'ASCII', or 'Unicode'.
+        /// </summary>
         [Alias("encoding", "enc")]
-        [Parameter(Mandatory = false)]
+        [Parameter(Mandatory = false, HelpMessage = "Specifies the encoding (codepage) for reading and writing the INI file (e.g., 'UTF8', 'Latin', 'ASCII', 'Unicode').")]
         public string Codepage { get; set; } = "Latin";
 
+        /// <summary>
+        /// Returns the appropriate <see cref="Encoding"/> instance based on the specified Codepage.
+        /// </summary>
+        /// <returns>The <see cref="Encoding"/> for the specified codepage.</returns>
         protected Encoding GetEncoding()
         {
             string page = Codepage?.ToLower();
             switch (page)
             {
-                case "uft8": return Encoding.UTF8;
+                case "uft8":
+                    return Encoding.UTF8;
                 case "latin":
                 case "latin1":
-                case "ISO-8859-1":
+                case "iso-8859-1":
                     return Encoding.Latin1;
                 case "asci":
                 case "ascii":
@@ -105,43 +167,57 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
             return Encoding.Default;
         }
 
+        /// <summary>
+        /// Processes the record by loading the specified INI file, updating, adding, or removing the specified key/value pair,
+        /// and then saving the file.
+        /// </summary>
         protected override void ProcessRecord()
         {
+            // Check if the specified INI file exists; if not, exit the method.
             if (!File.Exists(FilePath))
                 return;
 
+            // Configure INI file options based on provided parameters.
             var iniOptions = new IniOptions()
             {
                 Encoding = GetEncoding(),
                 SectionDuplicate = KeepSectionDuplicates ? IniDuplication.Allowed : IniDuplication.Ignored,
                 KeyDuplicate = KeepKeyDuplicates ? IniDuplication.Allowed : IniDuplication.Ignored,
             };
+
+            // Load the INI file with the specified options.
             var ini = new IniFile(iniOptions);
             ini.Load(FilePath);
 
+            // Retrieve the specified section; if not found and appending/updating is not allowed, exit.
             var iniSection = ini.Sections[Section];
             if (iniSection == null && !AlwaysAppend && !UpdateOrAdd)
                 return;
 
-            // create new if not existing
+            // Create a new section if it does not exist.
             if (iniSection == null)
             {
                 iniSection = new IniSection(ini, Section);
                 ini.Sections.Add(iniSection);
             }
 
+            // Function for matching a key using case-insensitive comparison.
             bool keyMatcher(IniKey x) => string.Equals(x.Name, Key, StringComparison.OrdinalIgnoreCase);
 
+            // If the operation is to remove or clear keys, perform deletion of matching keys.
             if (OnlyRemove || Clear)
             {
                 var list = iniSection.Keys.Where(keyMatcher).ToList();
                 list.ForEach(x => iniSection.Keys.Remove(x));
             }
 
+            // If removal is not the only operation, proceed with updating or adding the value.
             if (!OnlyRemove)
             {
                 // assuming most of the engines interpret INI files from top to bottom using the last value of a multiple existing key, we update the last found key
                 var firstMatch = iniSection.Keys.LastOrDefault(keyMatcher);
+                // If appending is always enabled or the key is being added, insert a new key-value pair
+                // Insert a new key-value pair if appending is enforced or the key does not exist.
                 if (AlwaysAppend.ToBool() || (UpdateOrAdd && firstMatch == null))
                 {
                     if (InsertIndex.HasValue && InsertIndex.Value >= 0)
@@ -151,7 +227,11 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
                 }
                 else if (firstMatch != null)
                 {
-                    var insertIndex = (InsertIndex.HasValue && InsertIndex.Value >= 0) ? Math.Clamp(InsertIndex.Value, 0, iniSection.Keys.Count - 1)  : -1;
+                    // Handle updating an existing key, optionally repositioning it if an insertion index is specified.
+                    var insertIndex = (InsertIndex.HasValue && InsertIndex.Value >= 0)
+                        ? Math.Clamp(InsertIndex.Value, 0, iniSection.Keys.Count - 1)
+                        : -1;
+
                     if (insertIndex >= 0)
                     {
                         iniSection.Keys.Remove(firstMatch);
@@ -159,9 +239,10 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
                     }
                     firstMatch.Value = Value;
                 }
-                // no else, as it should be possible to only update an existing value without adding a new one
+                // No else clause – updating without adding a new key should be possible.
             }
 
+            // Save the modified INI file.
             ini.Save(FilePath);
         }
     }

--- a/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
+++ b/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
@@ -120,8 +120,15 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
             ini.Load(FilePath);
 
             var iniSection = ini.Sections[Section];
-            if (iniSection == null)
+            if (iniSection == null && !AlwaysAppend && !UpdateOrAdd)
                 return;
+
+            // create new if not existing
+            if (iniSection == null)
+            {
+                iniSection = new IniSection(ini, Section);
+                ini.Sections.Add(iniSection);
+            }
 
             bool keyMatcher(IniKey x) => string.Equals(x.Name, Key, StringComparison.OrdinalIgnoreCase);
 

--- a/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
+++ b/LANCommander.SDK/PowerShell/Cmdlets/Update-IniValue.cs
@@ -35,7 +35,14 @@ namespace LANCommander.SDK.PowerShell.Cmdlets
 
         [Parameter(Mandatory = false)]
         [Alias("add")]
-        public bool UpdateOrAdd { get; set; } = true;
+        public SwitchParameter UpdateOrAdd { get; set; } = true;
+        [Alias("update-only", "only-update")]
+        [Parameter(Mandatory = false)]
+        public SwitchParameter NoAdd
+        {
+            get => new(!UpdateOrAdd);
+            set => UpdateOrAdd = !value.ToBool();
+        }
 
         [Alias("remove-only")]
         [Parameter(Mandatory = false)]


### PR DESCRIPTION
Utilizing MadMilkman.INI for ini parsing handling multi-value section entries 

> [!WARNING]  
> PeanutButter.INI needs to be removed if this PR is merged.


Issue:  
[PeanutButter.INI](https://github.com/fluffynuts/PeanutButter) is currently used but it strips out every duplicate key which is causing _Unreal-Engine_ ini files (and similar) to be unusable/corrupt due to removing critical parts of the ini setting.

Changes:
- Extended Update-IniValue cmdlet, adding parameters to handle "CRUD" operations
- INI will read configs such as UT2004.ini properly without removing crucial sections
- Last setting matching a key name will be updated
- Uses **MadMilkman.Ini** ([Github](https://github.com/MarioZ/MadMilkman.Ini) | [nuget](https://www.nuget.org/packages/MadMilkman.Ini)) for .NET2.0, there is also a [_unofficial_ package having .NET Standard 2.0](https://github.com/MaxSKash/libinidotnet)


## Examples

The following example INI file is used for all examples.
```ini
[DefaultPlayer]
Class=Engine.Pawn
Name=Player
Name=Player1
Character=Jakob
team=255
Name=Player2
```

<details>
  <summary>( click for examples )</summary>

### Update
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini"
```

Result:
```ini
[DefaultPlayer]
Class=Engine.Pawn
Name=Player
Name=Player1
Character=Jakob
team=255
Name=Admin
```

### Update and remove duplicates
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini" -KeepKeyDuplicates 0
```

Result:
```ini
[DefaultPlayer]
Class=Engine.Pawn
Name=Admin
Character=Jakob
team=255
```

### Deleting
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini" -remove-only
```

Result:
```ini
[DefaultPlayer]
Class=Engine.Pawn
Character=Jakob
team=255
```

### Appending
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini" -append
```

Result:
```ini
[DefaultPlayer]
Class=Engine.Pawn
Name=Player
Name=Player1
Character=Jakob
team=255
Name=Player2
Name=Admin
```

### Inserting
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini" -insert 0
```

Result:
```ini
[DefaultPlayer]
Name=Admin
Class=Engine.Pawn
Name=Player
Name=Player1
Character=Jakob
team=255
```

### Inserting + clear
```ps1
Update-IniValue -s "DefaultPlayer" -k "Name" -v "Admin" -f "$InstallDirectory\System\User.ini" -insert 0 -clear
```

Result:
```ini
[DefaultPlayer]
Name=Admin
Class=Engine.Pawn
Character=Jakob
team=255
```

</details>

---

## Wiki

<details>
  <summary>Update-IniValue</summary>

Update-IniValue
---------------


Updates the value of an INI file.
 
### Syntax

```ps1
Update-IniValue
    -s, -Section <string>                          Specifies the section in the INI file that contains the key to be updated.
    -k, -Key <string>                              Specifies the key within the section whose value should be updated.
    -v, -Value <string>                            Specifies the new value to assign to the provided key.
    -f, -FilePath <string>                         Specifies the file path to the INI file that should be processed.

    Optional:
    -wrap, -WrapValueInQuotes <bool?>              Controls whether the value will be wrapped in quotes.
                                                   If true, quotes are enforced.
                                                   If false, quotes are removed.
                                                   If null, the quoting style of the existing INI value is preserved.
    -add, -UpdateOrAdd <bool>                      If set, the cmdlet will update an existing key or add a new one if it does not exist.
    -update-only, -NoAdd                           Restricts the operation to updating existing entries; prevents adding new key-value pairs.
    -remove-only, -OnlyRemove                      Removes the key from the section without updating or adding new entries.
    -Clear                                         Clears all instances of the specified key in the section before inserting the new value.
    -append, -AlwaysAppend                         Appends a new key-value pair without replacing existing entries (useful for multi-value INI settings).
    -insert, -InsertIndex <int?>                   Specifies the zero-based index at which to insert the new key-value pair.
    -keepkey, -KeepKeyDuplicates <bool>            Determines whether duplicate keys within the section should be preserved.
    -nokey, -NoKeyDuplicates                       Prevents duplicate keys in the section.
    -keepsec, -KeepSectionDuplicates <bool>        Determines whether duplicate sections should be preserved.
    -nosec, -NoSectionDuplicates                   Prevents duplicate sections in the INI file.
    -enc, -Codepage <ENCODING>                     Specifies the encoding format for reading and writing the INI file (e.g., UTF8, Latin, ASCII, Unicode).

```

</details>
