### PR TITLE
Expiring Archives cache after recalculating/updating archives

### DIFF
--- a/LANCommander.Server.Services/ArchiveService.cs
+++ b/LANCommander.Server.Services/ArchiveService.cs
@@ -84,6 +84,7 @@ namespace LANCommander.Server.Services
         public override async Task<Archive> UpdateAsync(Archive updatedArchive)
         {
             await cache.ExpireGameCacheAsync(updatedArchive.GameId);
+            await cache.ExpireArchiveCacheAsync(updatedArchive.Id);
             
             return await base.UpdateAsync(updatedArchive, async context =>
             {
@@ -98,6 +99,7 @@ namespace LANCommander.Server.Services
             FileHelpers.DeleteIfExists(await GetArchiveFileLocationAsync(archive));
 
             await cache.ExpireGameCacheAsync(archive.GameId);
+            await cache.ExpireArchiveCacheAsync(archive.Id);
 
             await base.DeleteAsync(archive);
         }

--- a/LANCommander.Server.Services/Extensions/CacheExtensions.cs
+++ b/LANCommander.Server.Services/Extensions/CacheExtensions.cs
@@ -11,8 +11,26 @@ public static class CacheExtensions
     public static async Task ExpireGameCacheAsync(this IFusionCache cache, Guid? gameId)
     {
         if (gameId.HasValue)
-            await cache.RemoveByTagAsync([ $"Games/{gameId}", "Games", "Depot"]);
+            await cache.RemoveByTagAsync([ 
+                $"Games/{gameId}",
+                "Games", 
+                "Depot",
+                $"Games/{gameId}/Archives",
+            ]);
         else
             await cache.RemoveByTagAsync(["Games", "Depot"]);
+    }
+
+    public static Task ExpireArchiveCacheAsync(this IFusionCache cache)
+    {
+        return ExpireArchiveCacheAsync(cache, archiveId: null);
+    }
+
+    public static async Task ExpireArchiveCacheAsync(this IFusionCache cache, Guid? archiveId)
+    {
+        if (archiveId.HasValue)
+            await cache.RemoveByTagAsync([$"Archives/{archiveId}"]);
+        else
+            await cache.RemoveByTagAsync(["Archives"]);
     }
 }

--- a/LANCommander.Server/Controllers/Api/ArchivesController.cs
+++ b/LANCommander.Server/Controllers/Api/ArchivesController.cs
@@ -117,7 +117,7 @@ namespace LANCommander.Server.Controllers.Api
                 }
 
                 return entries;
-            }, TimeSpan.MaxValue, tags: ["Archives", $"Archives/{id}"]);
+            }, TimeSpan.MaxValue, tags: ["Archives", $"Archives/{id}", $"Games/{archive.GameId}/Archives"]);
 
             if (entries.Count() == 0)
                 return NotFound();

--- a/LANCommander.Server/UI/Pages/Settings/Tools/Index.razor
+++ b/LANCommander.Server/UI/Pages/Settings/Tools/Index.razor
@@ -115,6 +115,7 @@
         await FusionCache.RemoveByTagAsync("Games");
         await FusionCache.RemoveByTagAsync("Depot");
         await FusionCache.RemoveByTagAsync("Library");
+        await FusionCache.RemoveByTagAsync("Archives");
 
         MessageService.Success("Cache cleared!");
     }


### PR DESCRIPTION
Expiring Archives cache after recalculating/updating archives which fixes the cached contents of archives. This helps when archives were updated/changed server-sided and the size were re-calculated.

Issue:
- When archives are udpated via "Recalculate File Sizes", clients still receive old data when _validating_ installation

Changes:
- Archives caches are specifically expired when updating and deleting archives
- New Archive tag `Games/{gameId}/Archives` to _store_ all archives by a game
- Tools action "Clear Cache" will invalidate Archives cache now
