### PR TITLE
Fix changing base game of a game

### DIFF
--- a/LANCommander.Server.Data/DatabaseContext.cs
+++ b/LANCommander.Server.Data/DatabaseContext.cs
@@ -1,4 +1,5 @@
 ﻿using LANCommander.Server.Data.Enums;
+using LANCommander.Server.Data.Interceptors;
 using LANCommander.Server.Data.Models;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
@@ -14,6 +15,8 @@ namespace LANCommander.Server.Data
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
+            optionsBuilder.AddInterceptors(new GameSaveChangesInterceptor());
+
             optionsBuilder.EnableDetailedErrors();
             optionsBuilder.EnableSensitiveDataLogging();
 

--- a/LANCommander.Server.Data/Interceptors/GameSaveChangesInterceptor.cs
+++ b/LANCommander.Server.Data/Interceptors/GameSaveChangesInterceptor.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore;
+using LANCommander.Server.Data.Models;
+using LANCommander.SDK.Enums;
+
+namespace LANCommander.Server.Data.Interceptors
+{
+    public class GameSaveChangesInterceptor : SaveChangesInterceptor
+    {
+        private void EnforceBusinessRules(DbContext? context)
+        {
+            if (context == null)
+                return;
+
+            foreach (var entry in context.ChangeTracker.Entries<Game>())
+            {
+                if (entry.State == EntityState.Added || entry.State == EntityState.Modified)
+                {
+                    var game = entry.Entity;
+
+                    // If the game type is MainGame, clear the BaseGame relationship.
+                    if (game.Type == GameType.MainGame)
+                    {
+                        game.BaseGame = null;
+                        game.BaseGameId = null;
+                    }
+                    // prevent recursion, referencing itself as base
+                    else if (game.BaseGameId == game.Id)
+                    {
+                        game.BaseGame = null;
+                        game.BaseGameId = null;
+                    }
+                }
+            }
+        }
+
+        public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+        {
+            EnforceBusinessRules(eventData.Context);
+            return base.SavingChanges(eventData, result);
+        }
+
+        public override ValueTask<InterceptionResult<int>> SavingChangesAsync(
+            DbContextEventData eventData,
+            InterceptionResult<int> result,
+            CancellationToken cancellationToken = default)
+        {
+            EnforceBusinessRules(eventData.Context);
+            return base.SavingChangesAsync(eventData, result, cancellationToken);
+        }
+    }
+}

--- a/LANCommander.Server/UI/Pages/Games/Edit/General.razor
+++ b/LANCommander.Server/UI/Pages/Games/Edit/General.razor
@@ -205,6 +205,7 @@
         {
             if (game.Id != Guid.Empty)
             {
+                game.BaseGame = null; // clearing base game, model setup will write the BaseGameId value, referenced model will be loaded on update/get
                 game = await GameService.UpdateAsync(game);
 
                 await MessageService.Success("Game updated!");

--- a/LANCommander.Server/UI/Pages/Games/Edit/General.razor
+++ b/LANCommander.Server/UI/Pages/Games/Edit/General.razor
@@ -92,7 +92,7 @@
                     <Flex Gap="FlexGap.Small" Wrap="FlexWrap.NoWrap">
                         <Select TItem="Game"
                                 TItemValue="Guid?"
-                                DataSource="@Games.OrderBy(g => String.IsNullOrWhiteSpace(g.SortTitle) ? g.Title : g.SortTitle)"
+                                DataSource="@Games.Where(g => g.Id != context.Id).OrderBy(g => String.IsNullOrWhiteSpace(g.SortTitle) ? g.Title : g.SortTitle)"
                                 @bind-Value="@context.BaseGameId"
                                 LabelName="Title"
                                 ValueName="Id"


### PR DESCRIPTION
Fixes the issue not being able to change base game of a game

Issues:
- Once base game is set and stored, any changes to the selection won't be saved
- Selecting different type and select a base game, or having it already set, changing tpye to `MainGame` again, will keep the referenced stored
- Games can reference themselves as base game

Changes: 
- Clearing BaseGame instance of a model to prevent overwriting `BaseGameId`
- Remove selected game from Games data source
- Using intercepter to fix properties on saving

<details>
  <summary>Image of self-referencing</summary>

![Issue-SelfReference](https://github.com/user-attachments/assets/89e1eddb-0a23-4938-b224-085cdf446dee)

  
</details>


<details>
  <summary>Demonstration</summary>

<p>Bug:</p>

https://github.com/user-attachments/assets/b57d3995-b513-4929-8f8d-7ed0a9f29ec0

<p><strong>Fix:</strong></p>

https://github.com/user-attachments/assets/04393ea8-ef8a-4cfc-82a9-c11ad7c16ef6
  
</details>