### PR TITLE
Standalone mods/expansions as Base Game

### DIFF
--- a/LANCommander.Server/UI/Pages/Games/Edit/General.razor
+++ b/LANCommander.Server/UI/Pages/Games/Edit/General.razor
@@ -185,6 +185,8 @@
 
     private async Task LoadData()
     {
+        var allowedTypes = new[] { GameType.MainGame, GameType.StandaloneExpansion, GameType.StandaloneMod };
+
         Engines = await EngineService.SortBy(g => g.Name).GetAsync();
         Companies = await CompanyService.SortBy(g => g.Name).GetAsync();
         Genres = await GenreService.SortBy(g => g.Name).GetAsync();
@@ -193,7 +195,8 @@
         Collections = await CollectionService.SortBy(g => g.Name).GetAsync();
         Games = (await GameService
             .Include(g => g.Media.Where(m => m.Type == MediaType.Icon))
-            .GetAsync(g => g.Type == GameType.MainGame)).OrderByTitle(g => String.IsNullOrWhiteSpace(g.SortTitle) ? g.Title : g.SortTitle);
+            .GetAsync(g => allowedTypes.Contains(g.Type)))
+            .OrderByTitle(g => String.IsNullOrWhiteSpace(g.SortTitle) ? g.Title : g.SortTitle);
         Redistributables = (await RedistributableService.GetAsync()).OrderByTitle(r => r.Name);
 
         Loaded = true;


### PR DESCRIPTION
Ability to set base game to standalone mods/expansions as well

This includes the following:
- Allow UI to set base game to any other standalone mod or expansion as well
- Installing works the same way as with main game base games, no change needed


<details>
  <summary>Demonstration</summary>

https://github.com/user-attachments/assets/340fa3e9-f87c-4550-a334-ce3fbb7c1114
  
</details>
