### PR TITLE
Fix storing several entities (such as Gamesaves) properly

### DIFF
--- a/LANCommander.Server.Services/_BaseDatabaseService.cs
+++ b/LANCommander.Server.Services/_BaseDatabaseService.cs
@@ -255,17 +255,15 @@ namespace LANCommander.Server.Services
                 newEntity.CreatedOn = DateTime.UtcNow;
                 newEntity.CreatedBy = currentUser;
                 //newEntity.CreatedById = currentUser?.Id;
-                
-                newEntity = (await context.AddAsync(newEntity)).Entity;
-                
-                await context.SaveChangesAsync();
-                
+
                 if (additionalMapping != null)
                 {
                     var updateContext = new UpdateEntityContext<T>(context, newEntity, addedEntity);
-                
+
                     additionalMapping?.Invoke(updateContext);
                 }
+
+                newEntity = (await context.AddAsync(newEntity)).Entity;
                 
                 await context.SaveChangesAsync();
 


### PR DESCRIPTION
Fixes the issue of storing/saving an uploaded save game

Referenced properties were not properly loaded causing constraint errors on saving. It will now update the mapping first which will load referenced models, and udpate the Id accordingly.

- Fixes #280

