### PR TITLE
Fix packaging and uploading save games by Launcher

### DIFF
--- a/LANCommander.SDK/Services/SaveService.cs
+++ b/LANCommander.SDK/Services/SaveService.cs
@@ -155,14 +155,16 @@ namespace LANCommander.SDK.Services
 
                     foreach (var savePath in manifest.SavePaths.Where(sp => sp.Type == Enums.SavePathType.File))
                     {
-                        foreach (var entry in savePath.Entries)
+                        var entries = Client.Saves.GetFileSavePathEntries(savePath, installDirectory) ?? [];
+
+                        foreach (var entry in entries)
                         {
                             var entryPath = Path.Combine(tempLocation, tempLocationFilePath, savePath.Id.ToString(), entry.ArchivePath.Replace('/', Path.DirectorySeparatorChar));
                             var destinationPath = entry.ActualPath.ExpandEnvironmentVariables(installDirectory);
 
                             if (File.Exists(entryPath))
                             {
-                                var destinationDirectory = Path.GetDirectoryName(entryPath);
+                                var destinationDirectory = Path.GetDirectoryName(destinationPath);
 
                                 Directory.CreateDirectory(destinationDirectory);
 
@@ -179,11 +181,11 @@ namespace LANCommander.SDK.Services
 
                                 foreach (var entryFile in entryFiles)
                                 {
-                                    var destinationDirectory = Path.GetDirectoryName(entryFile);
+                                    var fileDestination = entryFile.Replace(entryPath, destinationPath);
+                                    
+                                    var destinationDirectory = Path.GetDirectoryName(fileDestination);
 
                                     Directory.CreateDirectory(destinationDirectory);
-
-                                    var fileDestination = entryFile.Replace(entryPath, destinationPath);
 
                                     if (File.Exists(fileDestination))
                                         File.Delete(fileDestination);

--- a/LANCommander.SDK/Utilities/SavePackager.cs
+++ b/LANCommander.SDK/Utilities/SavePackager.cs
@@ -143,7 +143,7 @@ public class SavePacker : IDisposable
                 _archive.AddEntry($"Files/{savePathId}/{GetArchiveEntryName(file, absoluteLocalWorkingDirectory).TrimStart('/')}", file);
             }
         }
-        else
+        else if (File.Exists(absoluteFullLocalPath))
         {
             _archive.AddEntry(GetArchiveEntryName(absoluteFullLocalPath, absoluteLocalWorkingDirectory), absoluteFullLocalPath);
         }

--- a/LANCommander.SDK/Utilities/SavePackager.cs
+++ b/LANCommander.SDK/Utilities/SavePackager.cs
@@ -136,16 +136,19 @@ public class SavePacker : IDisposable
         var absoluteLocalPath = path.ExpandEnvironmentVariables(_installDirectory);
         var absoluteFullLocalPath = Path.Combine(absoluteLocalWorkingDirectory, absoluteLocalPath);
 
+        var archiveBaseFolder = $"Files/{savePathId}/";
         if (Directory.Exists(absoluteFullLocalPath))
         {
             foreach (var file in Directory.GetFiles(absoluteFullLocalPath, "*", SearchOption.AllDirectories))
             {
-                _archive.AddEntry($"Files/{savePathId}/{GetArchiveEntryName(file, absoluteLocalWorkingDirectory).TrimStart('/')}", file);
+                var archivePath = $"{archiveBaseFolder}{GetArchiveEntryName(file, absoluteLocalWorkingDirectory).TrimStart('/')}";
+                _archive.AddEntry(archivePath, file);
             }
         }
         else if (File.Exists(absoluteFullLocalPath))
         {
-            _archive.AddEntry(GetArchiveEntryName(absoluteFullLocalPath, absoluteLocalWorkingDirectory), absoluteFullLocalPath);
+            var archivePath = $"{archiveBaseFolder}{GetArchiveEntryName(absoluteFullLocalPath, absoluteLocalWorkingDirectory).TrimStart('/')}";
+            _archive.AddEntry(archivePath, absoluteFullLocalPath);
         }
     }
 


### PR DESCRIPTION
Fixes the issue of packaging save games when files not exists, also restores the save game properly 

- Fixes #279
- Fix packaging attempting to store non-existing files
- Fix storing save game files into "Files" subfolder for single-file save-paths
- Fix restoring save files by ensuring folders
- Reading entries of save path via `GetFileSavePathEntries(..)`
