### PR TITLE
Fix crash of base game removal of user Library

### DIFF
--- a/LANCommander.Server.Services/LibraryService.cs
+++ b/LANCommander.Server.Services/LibraryService.cs
@@ -74,16 +74,16 @@ namespace LANCommander.Server.Services
 
             var game = library.Games.FirstOrDefault(g => g.Id == gameId);
 
-            if (game.DependentGames != null && game.DependentGames.Any())
+            if (game != null && game.DependentGames != null && game.DependentGames.Any())
             {
                 foreach (var dependentGame in game.DependentGames)
                 {
                     if (library.Games.Any(g => g.Id == dependentGame.Id) && dependentGame.Id != game.Id)
-                        await RemoveFromLibraryAsync(userId, dependentGame.Id);
+                        library.Games.Remove(dependentGame);
                 }
             }
 
-            library.Games.Remove(game);
+            library.Games.Remove(game!);
 
             await UpdateAsync(library);
 

--- a/LANCommander.Server.Services/LibraryService.cs
+++ b/LANCommander.Server.Services/LibraryService.cs
@@ -78,8 +78,11 @@ namespace LANCommander.Server.Services
             {
                 foreach (var dependentGame in game.DependentGames)
                 {
-                    if (library.Games.Any(g => g.Id == dependentGame.Id) && dependentGame.Id != game.Id)
-                        library.Games.Remove(dependentGame);
+                    if (dependentGame.IsAddon)
+                    {
+                        if (library.Games.Any(g => g.Id == dependentGame.Id) && dependentGame.Id != game.Id)
+                            library.Games.Remove(dependentGame);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes the issue of removing a base game causing the server to crash and close

Issues:
- Removing a base game, when a _dependent_ is added, will crash the server and closes the instance
- Standalone games are also removed

Changes: 
- Removing base game keeps standalone games
- Fixes #263

<details>
  <summary>Demonstration</summary>

<p>Bug:</p>

https://github.com/user-attachments/assets/e744961b-5ae5-4cd7-8038-2710c55bcdc7

<p><strong>Fix:</strong></p>

https://github.com/user-attachments/assets/87207b7b-ee5a-43c4-9a66-ad9b29fee80b

</details>