### PR TITLE
Update archive's file sizes for a specific archive/game

### DIFF
--- a/LANCommander.Server.Services/ArchiveService.cs
+++ b/LANCommander.Server.Services/ArchiveService.cs
@@ -231,6 +231,33 @@ namespace LANCommander.Server.Services
             return size;
         }
 
+        public async Task<bool> RecalculateFileSizeArchiveAsync(Archive archive)
+        {
+            try
+            {
+                var path = await GetArchiveFileLocationAsync(archive);
+
+                if (File.Exists(path))
+                {
+                    archive.CompressedSize = await GetCompressedSizeAsync(archive);
+                    archive.UncompressedSize = await GetUncompressedSizeAsync(archive);
+
+                    await UpdateAsync(archive);
+                    return true;
+                }
+                else
+                {
+                    _logger?.LogWarning("No local file found for archive {ArchiveId} on path: {path}", archive.Id, path);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger?.LogError(ex, "Could not recalculate file size for archive {ArchiveId}", archive.Id);
+            }
+
+            return false;
+        }
+
         public async Task PatchArchiveAsync(Archive originalArchive, Archive alteredArchive, CompressionLevel compressionLevel = CompressionLevel.Optimal)
         {
             var alteredZipPath = await GetArchiveFileLocationAsync(alteredArchive);

--- a/LANCommander.Server/UI/Components/ArchiveEditor.razor
+++ b/LANCommander.Server/UI/Components/ArchiveEditor.razor
@@ -18,9 +18,10 @@
     Responsive
     Query="a => (GameId != Guid.Empty && a.GameId == GameId) || (RedistributableId != Guid.Empty && a.RedistributableId == RedistributableId)">
     <RightToolbar>
+        <Button OnClick="RecalculateFileSizes" Type="@ButtonType.Default">Recalculate File Sizes</Button>
         <Button OnClick="UploadArchive" Type="@ButtonType.Primary">Upload Archive</Button>
     </RightToolbar>
-    
+
     <Columns>
         <BoundDataColumn Property="a => a.Version">
             <Input Type="InputType.Text" Bordered="false" @bind-Value="context.Version" OnBlur="() => Update(context)"/>
@@ -37,11 +38,13 @@
         </BoundDataColumn>
 
         <DataActions TData="string">
+            <Button Icon="@IconType.Outline.Sync" Type="@ButtonType.Text" OnClick="() => RecalculateFileSize(context)" />
+
             <a href="/Download/Archive/@context.Id" target="_blank" class="ant-btn ant-btn-text ant-btn-icon-only">
                 <Icon Type="@IconType.Outline.Download"/>
             </a>
 
-            <Button Icon="@IconType.Outline.FolderOpen" Type="@ButtonType.Text" OnClick="() => BrowseArchive(context)"/>
+            <Button Icon="@IconType.Outline.FolderOpen" Type="@ButtonType.Text" OnClick="() => BrowseArchive(context)" />
 
             <Popconfirm Title="Are you sure you want to delete this archive?" OnConfirm="() => Delete(context)">
                 <Button Icon="@IconType.Outline.Close" Type="@ButtonType.Text" Danger/>
@@ -62,6 +65,46 @@
     protected override void OnInitialized()
     {
         HttpClient.BaseAddress = new Uri(Navigator.BaseUri);
+    }
+
+    private async Task RecalculateFileSizes()
+    {
+        MessageService.Info("Recalculating File Sizes...");
+
+        await Task.Yield();
+        await InvokeAsync(StateHasChanged);
+
+        var archives = Table.DataSource;
+
+        var results = new List<bool>();
+        foreach (var archive in archives)
+        {
+            var result = await archiveService.RecalculateFileSizeArchiveAsync(archive);
+            results.Add(result);
+        }
+
+        if (results.All(x => x))
+            MessageService.Success("File sizes recalculated!");
+        else
+            MessageService.Warning("File sizes recalculated but some failed!");
+
+        await Task.Yield();
+        await InvokeAsync(StateHasChanged);
+        Table.Reload();
+    }
+
+    private async Task RecalculateFileSize(Archive archive)
+    {
+        MessageService.Info("Recalculating File Sizes...");
+
+        archive = await archiveService.AsNoTracking().GetAsync(archive.Id);
+        var result = await archiveService.RecalculateFileSizeArchiveAsync(archive);
+        await ArchiveUploaded(archive.Id);
+
+        if(result)
+            MessageService.Success("File sizes recalculated!");
+        else
+            MessageService.Error("Recalculating file sizes failed!");
     }
 
     private async Task Download(Archive archive)

--- a/LANCommander.Server/UI/Pages/Settings/Tools/Index.razor
+++ b/LANCommander.Server/UI/Pages/Settings/Tools/Index.razor
@@ -82,27 +82,18 @@
         
         var archives = await ArchiveService.AsNoTracking().GetAsync();
 
+        var results = new List<bool>();
+
         foreach (var archive in archives)
         {
-            try
-            {
-                var path = await ArchiveService.GetArchiveFileLocationAsync(archive);
-
-                if (File.Exists(path))
-                {
-                    archive.CompressedSize = await ArchiveService.GetCompressedSizeAsync(archive);
-                    archive.UncompressedSize = await ArchiveService.GetUncompressedSizeAsync(archive);
-
-                    await ArchiveService.UpdateAsync(archive);
-                }
-            }
-            catch (Exception ex)
-            {
-                Logger?.LogError(ex, "Could not recalculate file size for archive {ArchiveId}", archive.Id);
-            }
+            var result = await ArchiveService.RecalculateFileSizeArchiveAsync(archive);
+            results.Add(result);
         }
 
-        MessageService.Success("File sizes recalculated!");
+        if (results.All(x => x))
+            MessageService.Success("File sizes recalculated!");
+        else
+            MessageService.Warning("File sizes recalculated but some failed!");
 
         RecalculatingFileSizes = false;
         


### PR DESCRIPTION
Adds option to update archive's file sizes for a specific archive/game

This includes the following:
- Button in list in Archives to update specific archive
- Button in Archives to update all archives of a game
- Tools action will report if some recalculating failed

<details>
  <summary>Video Demonstration</summary>

https://github.com/user-attachments/assets/420a8ac7-fca8-481b-894f-870ee98d2f50
 
</details>

![Screenshot](https://github.com/user-attachments/assets/aff61984-57e4-4a75-9a2c-57078e37e45d)

