### PR TITLE
Library changes to addon installation

### DIFF
--- a/LANCommander.Launcher.Models/DownloadQueueRedistributable.cs
+++ b/LANCommander.Launcher.Models/DownloadQueueRedistributable.cs
@@ -11,6 +11,7 @@ namespace LANCommander.Launcher.Models
     {
         public Guid Id { get; set; }
         public Guid[] AddonIds { get; set; }
+        public Dictionary<Guid, string?> AddonVersions { get; set; }
         public string Title { get; set; }
         public string Version { get; set; }
         public string InstallDirectory { get; set; }

--- a/LANCommander.Launcher.Models/IInstallQueueItem.cs
+++ b/LANCommander.Launcher.Models/IInstallQueueItem.cs
@@ -11,6 +11,7 @@ namespace LANCommander.Launcher.Models
     {
         Guid Id { get; set; }
         Guid[] AddonIds { get; set; }
+        Dictionary<Guid, string?> AddonVersions { get; set; }
         string Title { get; set; }
         string Version { get; set; }
         string InstallDirectory { get; set; }

--- a/LANCommander.Launcher.Models/InstallQueueGame.cs
+++ b/LANCommander.Launcher.Models/InstallQueueGame.cs
@@ -11,6 +11,7 @@ namespace LANCommander.Launcher.Models
     {
         public Guid Id { get; set; }
         public Guid[] AddonIds { get; set; }
+        public Dictionary<Guid, string?> AddonVersions { get; set; }
         public string Title { get; set; }
         public string Version { get; set; }
         public string InstallDirectory { get; set; }

--- a/LANCommander.Launcher.Services/GameService.cs
+++ b/LANCommander.Launcher.Services/GameService.cs
@@ -49,14 +49,10 @@ namespace LANCommander.Launcher.Services
                 try
                 {
                     OnUninstall?.Invoke(game);
-                    
+
                     await Client.Games.UninstallAsync(game.InstallDirectory, game.Id);
 
-                    game.InstallDirectory = null;
-                    game.Installed = false;
-                    game.InstalledOn = null;
-                    game.InstalledVersion = null;
-
+                    ClearGameState(game);
                     await UpdateAsync(game);
 
                     OnUninstallComplete?.Invoke(game);
@@ -77,7 +73,7 @@ namespace LANCommander.Launcher.Services
             if (Client.IsConnected())
             {
                 var profile = await Client.Profile.GetAsync();
-                
+
                 userId = profile.Id;
             }
             else
@@ -100,6 +96,22 @@ namespace LANCommander.Launcher.Services
             finally
             {
                 await PlaySessionService.EndSession(game.Id, userId);
+            }
+        }
+
+        protected void ClearGameState(Game game)
+        {
+            if (game == null)
+                return;
+
+            game.InstallDirectory = null;
+            game.Installed = false;
+            game.InstalledOn = null;
+            game.InstalledVersion = null;
+
+            foreach (var addon in (game.DependentGames ?? []))
+            {
+                ClearGameState(addon);
             }
         }
     }

--- a/LANCommander.Launcher.Services/GameService.cs
+++ b/LANCommander.Launcher.Services/GameService.cs
@@ -5,6 +5,7 @@ using LANCommander.SDK;
 using LANCommander.SDK.Extensions;
 using LANCommander.SDK.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.DependencyInjection;
 using System.Diagnostics;
 
 namespace LANCommander.Launcher.Services
@@ -13,6 +14,7 @@ namespace LANCommander.Launcher.Services
     {
         private readonly AuthenticationService AuthenticationService;
         private readonly PlaySessionService PlaySessionService;
+        private readonly IServiceProvider ServiceProvider;
         private readonly SaveService SaveService;
         private readonly MessageBusService MessageBusService;
 
@@ -32,12 +34,14 @@ namespace LANCommander.Launcher.Services
             ILogger<GameService> logger,
             AuthenticationService authenticationService,
             PlaySessionService playSessionService,
+            IServiceProvider serviceProvider,
             SaveService saveService,
             MessageBusService messageBusService) : base(dbContext, client, logger)
         {
             Settings = SettingService.GetSettings();
             AuthenticationService = authenticationService;
             PlaySessionService = playSessionService;
+            ServiceProvider = serviceProvider;
             SaveService = saveService;
             MessageBusService = messageBusService;
         }
@@ -51,6 +55,21 @@ namespace LANCommander.Launcher.Services
                     OnUninstall?.Invoke(game);
 
                     await Client.Games.UninstallAsync(game.InstallDirectory, game.Id);
+
+                    if (game.BaseGameId.HasValue)
+                    {
+                        var libraryService = ServiceProvider.GetService<LibraryService>();
+                        var isInstalled = await libraryService!.IsInstalledAsync(game.BaseGameId.Value);
+
+                        if (!isInstalled)
+                        {
+                            var baseGame = await GetAsync(game.BaseGameId.Value);
+
+                            await Client.Games.UninstallAsync(game.InstallDirectory, baseGame?.Id ?? game.BaseGameId.Value);
+
+                            ClearGameState(baseGame!, skipAddons: true);
+                        }
+                    }
 
                     ClearGameState(game);
                     await UpdateAsync(game);
@@ -99,7 +118,7 @@ namespace LANCommander.Launcher.Services
             }
         }
 
-        protected void ClearGameState(Game game)
+        protected void ClearGameState(Game game, bool skipAddons = false)
         {
             if (game == null)
                 return;
@@ -109,9 +128,12 @@ namespace LANCommander.Launcher.Services
             game.InstalledOn = null;
             game.InstalledVersion = null;
 
-            foreach (var addon in (game.DependentGames ?? []))
+            if (!skipAddons)
             {
-                ClearGameState(addon);
+                foreach (var addon in (game.DependentGames ?? []))
+                {
+                    ClearGameState(addon);
+                }
             }
         }
     }

--- a/LANCommander.Launcher.Services/ImportService.cs
+++ b/LANCommander.Launcher.Services/ImportService.cs
@@ -152,6 +152,12 @@ namespace LANCommander.Launcher.Services
                         }
                     }
 
+                    var childGamesIds = game.DependentGames.ToArray();
+                    foreach (var childGameId in childGamesIds)
+                    {
+                        await ImportGameAsync(childGameId);
+                    }
+                    
                     #region Update Game Engine
 
                     if (game.Engine == null && localGame.Engine != null)

--- a/LANCommander.Launcher.Services/InstallService.cs
+++ b/LANCommander.Launcher.Services/InstallService.cs
@@ -213,6 +213,9 @@ namespace LANCommander.Launcher.Services
 
                 if (localGame.Installed)
                 {
+                    // update current local installed game first, might be moved afterwards
+                    await Client.Games.UpdateGameInstallationAsync(localGame.InstallDirectory, remoteGame);
+
                     // Probably doing a modification of some sort
                     if (localGame.InstallDirectory.StartsWith(currentItem.InstallDirectory))
                     {

--- a/LANCommander.Launcher.Services/LibraryService.cs
+++ b/LANCommander.Launcher.Services/LibraryService.cs
@@ -138,9 +138,20 @@ namespace LANCommander.Launcher.Services
             return user.Library;
         }
 
+        private static bool IsInstalled(ListItem item)
+        {
+            return item != null && (item.State == ListItemState.Installed || item.State == ListItemState.UpdateAvailable);
+        }
+
         public bool IsInstalled(Guid itemId)
         {
-            return Items.Any(i => i.Key == itemId && (i.State == ListItemState.Installed || i.State == ListItemState.UpdateAvailable));
+            return Items.Any(i => i.Key == itemId && IsInstalled(i));
+        }
+
+        public async Task<bool> IsInstalledAsync(Guid itemId)
+        {
+            var items = await GetItemsAsync();
+            return items.Any(i => IsInstalled(i));
         }
 
         public bool IsInLibrary(Guid itemId)

--- a/LANCommander.Launcher.Services/LibraryService.cs
+++ b/LANCommander.Launcher.Services/LibraryService.cs
@@ -217,6 +217,7 @@ namespace LANCommander.Launcher.Services
                 .Include(g => g.Platforms)
                 .Include(g => g.Media)
                 .Include(g => g.MultiplayerModes)
+                .Include(g => g.DependentGames)
                 .FirstOrDefaultAsync(g => g.Id == key);
 
             return new ListItem(game);

--- a/LANCommander.Launcher/UI/Components/InstallDialog.razor
+++ b/LANCommander.Launcher/UI/Components/InstallDialog.razor
@@ -59,11 +59,10 @@
 
     string SelectedDirectory = "";
 
-    List<SDK.Models.Game> Addons = new();
-
     SDK.Models.Game RemoteGame;
     Data.Models.Game Game;
 
+    List<SDK.Models.Game> Addons = new();
     IEnumerable<SDK.Models.Game> SelectedAddons = new List<SDK.Models.Game>();
 
     enum InstallOperation
@@ -77,7 +76,7 @@
     protected override async Task OnInitializedAsync()
     {
         Game = Options.DataItem as Game;
-        
+
         if (Game.Installed)
             SelectedDirectory = Settings.Games.InstallDirectories.FirstOrDefault(d => Game.InstallDirectory.StartsWith(d));
 
@@ -86,6 +85,9 @@
 
         RemoteGame = await Client.Games.GetAsync(Options.Key);
         Addons = (await Client.Games.GetAddonsAsync(Options.Key)).OrderByTitle(g => g.SortTitle ?? g.Title).ToList();
+
+        var localAddons = Game?.DependentGames.Where(g => g.Installed).Select(addon => addon.Id).ToArray() ?? [];
+        SelectedAddons = Addons?.Where(addon => localAddons.Contains(addon.Id)).ToList() ?? [];
     }
 
     async Task Close()
@@ -97,7 +99,7 @@
     {
         var game = Options.DataItem as Game;
 
-        InstallService.Add(game, SelectedDirectory, SelectedAddons.Select(a => a.Id).ToArray());
+        InstallService.Add(game, SelectedDirectory, SelectedAddons.ToArray());
 
         await CloseFeedbackAsync();
     }

--- a/LANCommander.Launcher/UI/Components/InstallDialog.razor
+++ b/LANCommander.Launcher/UI/Components/InstallDialog.razor
@@ -109,7 +109,7 @@
         if (!Game.Installed)
             return InstallOperation.Install;
 
-        if (Game.DependentGames.Any(g => !g.Installed && SelectedAddons.Any(a => a.Id == g.Id)))
+        if (Game.DependentGames.Any(g => g.Installed ^ SelectedAddons.Any(a => a.Id == g.Id)))
             return InstallOperation.Modify;
 
         if (!Game.InstallDirectory.StartsWith(SelectedDirectory))

--- a/LANCommander.Launcher/UI/Components/ValidateFilesDialog.razor
+++ b/LANCommander.Launcher/UI/Components/ValidateFilesDialog.razor
@@ -25,11 +25,19 @@
             <ByteSize Value="context.Length" />
         }
     </PropertyColumn>
+    <Column TData="string" Title="Source Game">
+        @{
+            GameTitleMap.TryGetValue(context.GameId.GetValueOrDefault(Guid.Empty), out var title);
+        }
+        @(title ?? Options.Title)
+    </Column>
 </Table>
 
 @code {
     IEnumerable<ArchiveValidationConflict> Conflicts = new List<ArchiveValidationConflict>();
     IEnumerable<ArchiveValidationConflict> Selected = new List<ArchiveValidationConflict>();
+
+    IDictionary<Guid, string> GameTitleMap = new Dictionary<Guid, string>();
 
     bool Loading = true;
 
@@ -45,6 +53,9 @@
 
     async Task LoadData()
     {
+        var localAddons = Options.DependentGames?.Where(g => g.Installed).ToArray() ?? [];
+        GameTitleMap = localAddons.ToDictionary(x => x.Id, x => x.Title);
+
         Conflicts = await Client.Games.ValidateFilesAsync(Options.InstallDirectory, Options.Id);
 
         Loading = false;
@@ -56,7 +67,7 @@
         StateHasChanged();
         await Task.Yield();
 
-        await Client.Games.DownloadFilesAsync(Options.InstallDirectory, Options.Id, Selected.Select(e => e.FullName));
+        await Client.Games.DownloadFilesAsync(Options.InstallDirectory, Selected.Select(e => (e.GameId ?? Options.Id, e.FullName)).ToArray());
 
         Loading = false;
         StateHasChanged();

--- a/LANCommander.SDK/ExtractionResult.cs
+++ b/LANCommander.SDK/ExtractionResult.cs
@@ -11,5 +11,13 @@ namespace LANCommander.SDK
         public bool Success { get; set; }
         public bool Canceled { get; set; }
         public string Directory { get; set; }
+
+        public List<FileEntry> Files { get; internal set; } = [];
+
+        public class FileEntry
+        {
+            public string EntryPath { get; set; }
+            public string LocalPath { get; set; }
+        }
     }
 }

--- a/LANCommander.SDK/Helpers/ScriptHelper.cs
+++ b/LANCommander.SDK/Helpers/ScriptHelper.cs
@@ -37,13 +37,18 @@ namespace LANCommander.SDK.Helpers
             return tempPath;
         }
 
-        public static async Task SaveScriptAsync(Game game, ScriptType type)
+        public static Task SaveScriptAsync(Game game, ScriptType type)
+        {
+            return SaveScriptAsync(game, type, game.InstallDirectory);
+        }
+        
+        public static async Task SaveScriptAsync(Game game, ScriptType type, string installDirectory)
         {
             var scriptContents = GetScriptContents(game, type);
 
             if (!String.IsNullOrWhiteSpace(scriptContents))
             {
-                var filename = GetScriptFilePath(game.InstallDirectory, game.Id, type);
+                var filename = GetScriptFilePath(installDirectory, game.Id, type);
 
                 if (!Directory.Exists(Path.GetDirectoryName(filename)))
                     Directory.CreateDirectory(Path.GetDirectoryName(filename));

--- a/LANCommander.SDK/Models/ArchiveValidationConflict.cs
+++ b/LANCommander.SDK/Models/ArchiveValidationConflict.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace LANCommander.SDK.Models
 {
@@ -9,5 +10,7 @@ namespace LANCommander.SDK.Models
         public uint Crc32 { get; set; }
         public long Length { get; set; }
         public FileInfo LocalFileInfo { get; set; }
+
+        public Guid? GameId { get; internal set; }
     }
 }

--- a/LANCommander.SDK/Models/GameInstallationArchive.cs
+++ b/LANCommander.SDK/Models/GameInstallationArchive.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LANCommander.SDK.Services;
+
+public class GameInstallationArchiveInfo
+{
+    public GameManifest Manifest { get; internal set; }
+    public List<ArchiveEntry> Entries { get; private set; } = [];
+    public List<SavePathEntry> SavePaths { get; internal set; }
+}
+
+public class GameInstallationArchiveEntries
+{
+    public GameInstallationArchiveInfo BaseGame { get; internal set; } = new();
+    public Dictionary<Guid, GameInstallationArchiveInfo> DependentGames { get; private set; } = [];
+}

--- a/LANCommander.SDK/Models/GameInstallationFileList.cs
+++ b/LANCommander.SDK/Models/GameInstallationFileList.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LANCommander.SDK.Services;
+
+public class GameInstallationFileListEntry
+{
+    public class FileEntry
+    {
+        public string EntryPath { get; set; }
+        public string LocalPath { get; set; }
+    }
+
+    public Guid GameId { get; internal set; }
+
+    public GameManifest Manifest { get; internal set; }
+    public List<FileEntry> Files { get; private set; } = [];
+
+    public void Merge(GameInstallationFileListEntry otherInfo)
+    {
+        Manifest ??= otherInfo.Manifest;
+
+        var newFiles = otherInfo?.Files?.ExceptBy(Files.Select(entry => entry.EntryPath), entry => entry.EntryPath, StringComparer.OrdinalIgnoreCase) ?? [];
+        Files.AddRange(newFiles);
+    }
+
+    internal void AddFiles(IEnumerable<FileEntry> gameFiles)
+    {
+        Files.AddRange(gameFiles ?? []);
+    }
+
+    internal void AddFile(FileEntry gameFile)
+    {
+        ArgumentNullException.ThrowIfNull(gameFile);
+
+        Files.Add(gameFile);
+    }
+}
+
+public class GameInstallationFileList
+{
+    public static GameInstallationFileList Empty => new();
+
+    protected GameInstallationFileList()
+    {
+    }
+
+    public GameInstallationFileList(string installDirectory, Guid gameId)
+    {
+        BaseGame.GameId = gameId;
+        InstallDirectory = installDirectory;
+    }
+
+    public string InstallDirectory { get; internal set; }
+
+    public GameInstallationFileListEntry BaseGame { get; internal set; } = new();
+    public Dictionary<Guid, GameInstallationFileList> DependentGames { get; private set; } = [];
+
+    public void Merge(GameInstallationFileList gameFileList)
+    {
+        MergeBase(gameFileList);
+        MergeDependentGames(gameFileList);
+    }
+
+    public void MergeBase(GameInstallationFileList gameFileList)
+    {
+        BaseGame.Merge(gameFileList.BaseGame);
+    }
+
+    public void MergeBaseAsDependentGame(Guid gameId, GameInstallationFileList gameFileList)
+    {
+        if (!DependentGames.TryGetValue(gameId, out var depFileList))
+        {
+            depFileList = new(gameFileList.InstallDirectory, gameId);
+            DependentGames.Add(gameId, depFileList);
+            depFileList.BaseGame.Manifest = gameFileList.BaseGame.Manifest;
+        }
+
+        depFileList.BaseGame.Merge(gameFileList.BaseGame);
+    }
+
+    public void MergeDependentGames(GameInstallationFileList gameFileList)
+    {
+        foreach ((var otherDependentGameId, var otherDependentFileList) in gameFileList?.DependentGames ?? [])
+        {
+            if (!DependentGames.TryGetValue(otherDependentGameId, out var depFileList))
+            {
+                depFileList = new(gameFileList.InstallDirectory, otherDependentGameId);
+                DependentGames.Add(otherDependentGameId, depFileList);
+                //depFileList.BaseGame.Manifest = otherDependentFileList.;
+            }
+
+            depFileList.MergeDependentGames(otherDependentFileList);
+        }
+    }
+
+    public IEnumerable<GameInstallationFileListEntry.FileEntry> ToFlatDistinctFileEntries()
+    {
+        return BaseGame.Files
+            .Concat(DependentGames.Values.SelectMany(dep => dep.BaseGame.Files))
+            .GroupBy(file => file.EntryPath, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First()); // Ensures distinct entries by EntryPath
+    }
+}

--- a/LANCommander.SDK/Services/GameService.cs
+++ b/LANCommander.SDK/Services/GameService.cs
@@ -917,9 +917,18 @@ namespace LANCommander.SDK.Services
 
             if ((game.Type == GameType.Expansion || game.Type == GameType.Mod || game.Type == GameType.StandaloneMod) && game.BaseGameId != Guid.Empty)
             {
-                var baseGame = await Client.Games.GetAsync(game.BaseGameId);
+                // modify installation passes the original installation of the game including the game folder, use the existing folder,
+                // otherwise a name change could lead to installing files into differnt folder
+                if (Path.Exists(installDirectory) && Path.Exists(Path.Combine(installDirectory, ".lancommander")))
+                {
+                    return installDirectory;
+                }
+                else
+                {
+                    var baseGame = await Client.Games.GetAsync(game.BaseGameId);
 
-                return await GetInstallDirectory(baseGame, installDirectory);
+                    return await GetInstallDirectory(baseGame, installDirectory);
+                }
             }
             else
                 return Path.Combine(installDirectory, game.Title.SanitizeFilename());

--- a/LANCommander.SDK/Services/GameService.cs
+++ b/LANCommander.SDK/Services/GameService.cs
@@ -113,11 +113,14 @@ namespace LANCommander.SDK.Services
                 {
                     try
                     {
+                        if (ManifestHelper.Exists(installDirectory, dependentGameId))
+                        {
                             var dependentGameManifest = await ManifestHelper.ReadAsync<GameManifest>(installDirectory, dependentGameId);
 
-                        if (dependentGameManifest.Type == GameType.Expansion || dependentGameManifest.Type == GameType.Mod)
+                            if (dependentGameManifest?.Type == GameType.Expansion || dependentGameManifest?.Type == GameType.Mod)
                                 manifests.Add(dependentGameManifest);
                         }
+                    }
                     catch (Exception ex)
                     {
                         Logger?.LogError(ex, $"Could not load manifest from dependent game {dependentGameId}");
@@ -332,7 +335,7 @@ namespace LANCommander.SDK.Services
 
                 if (!Directory.Exists(destination))
                     destination = await InstallAsync(game.BaseGameId, installDirectory, null, maxAttempts);
-                }
+            }
 
             try
             {

--- a/LANCommander.SDK/Services/RedistributableService.cs
+++ b/LANCommander.SDK/Services/RedistributableService.cs
@@ -166,6 +166,7 @@ namespace LANCommander.SDK.Services
             }
 
             var destination = Path.Combine(GameService.GetMetadataDirectoryPath(game.InstallDirectory, redistributable.Id), "Files");
+            var files = new List<ExtractionResult.FileEntry>();
 
             Logger?.LogTrace("Downloading and extracting {Redistributable} to path {Destination}", redistributable.Name, destination);
 
@@ -195,6 +196,12 @@ namespace LANCommander.SDK.Services
 
                     reader.EntryExtractionProgress += (sender, e) =>
                     {
+                        files.Add(new ExtractionResult.FileEntry
+                        {
+                            EntryPath = e.Item.Key,
+                            LocalPath = Path.Combine(destination, e.Item.Key),
+                        });
+
                         OnArchiveEntryExtractionProgress?.Invoke(this, new ArchiveEntryExtractionProgressArgs
                         {
                             Entry = e.Item,
@@ -232,6 +239,7 @@ namespace LANCommander.SDK.Services
             {
                 extractionResult.Success = true;
                 extractionResult.Directory = destination;
+                extractionResult.Files = files;
                 Logger?.LogTrace("Redistributable {Redistributable} successfully downloaded and extracted to {Destination}", redistributable.Name, destination);
             }
 


### PR DESCRIPTION
Allows to uninstall/install addons, validates files properly

Issues:
- Files of addons get overwritten when validating
- Modify dialog is not available
- Uninstall addons/games were still flagged as being installed

This PR includes the following:
- Fixes Modify dialog
- Option to install/uninstall addons at will
- Respecting installed addons overwriting files (validating reverts to overwritten instead of original)
- Stores addons locally for keeping flag of being installed, update flag accordingly
- Fixes #267

Technical changes:
- Updates manifest/scripts when modifying game installation
- Installation/Modify/Uninstall methods return proper response. which is utilized to automatically validate and restore files

<details>
  <summary>Video Demonstration</summary>

<p>Issues:</p>

https://github.com/user-attachments/assets/fa8ac3d9-9005-4cf0-9ef3-7a05ca91ed52

<p><strong>Feature:</strong></p>

https://github.com/user-attachments/assets/719b6c51-97ef-4307-8a82-069de8dd7d57

</details>
