### PR TITLE
Fix context menu items not triggering on click

### DIFF
--- a/LANCommander.Launcher/Styles/_library.scss
+++ b/LANCommander.Launcher/Styles/_library.scss
@@ -21,6 +21,15 @@
     }
 }
 
+.library-context {
+    .ant-dropdown-menu-item {
+        &.primary-action {
+            font-weight: 600;
+            color: #fff;
+        }
+    }
+}
+
 .library-list {
     position: relative;
     z-index: 500;

--- a/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
@@ -105,7 +105,7 @@ else
     [Parameter] public RenderFragment MenuExtra { get; set; }
 
     Data.Models.Game Game { get; set; }
-    IEnumerable<SDK.Models.Action> GameActions { get; set; }
+    IEnumerable<SDK.Models.Action> GameActions { get; set; } = [];
 
     Settings Settings;
 
@@ -116,18 +116,22 @@ else
 
     protected override async Task OnParametersSetAsync()
     {
-        if (Model.DataItem is Game)
+        if (Model.DataItem is Game game)
         {
-            Game = Model.DataItem as Game;
-            GameActions = new List<SDK.Models.Action>();
+            Game = game;
+            List<SDK.Models.Action> actions = [];
 
             if (Game.Installed)
             {
                 var manifest = await ManifestHelper.ReadAsync<GameManifest>(Game.InstallDirectory, Game.Id);
 
                 if (manifest != null)
-                    GameActions = manifest.Actions.Where(a => !a.IsPrimaryAction).ToList();
+                    actions = manifest.Actions.Where(a => !a.IsPrimaryAction).ToList();
+
             }
+
+            GameActions = actions;
+            StateHasChanged();
         }
     }
 

--- a/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
@@ -15,7 +15,7 @@
 {
     @foreach (var action in GameActions.OrderBy(a => a.SortOrder))
     {
-        <MenuItem OnClick="() => Run(Game, action)">
+        <MenuItem OnClick="() => Run(Game, action)" Class="@(action.IsPrimaryAction ? "primary-action" : "")">
             @action.Name
         </MenuItem>
     }
@@ -103,6 +103,7 @@ else
 @code {
     [Parameter] public Models.ListItem Model { get; set; }
     [Parameter] public RenderFragment MenuExtra { get; set; }
+    [Parameter] public bool ShowPrimaryActions { get; set; }
 
     Data.Models.Game Game { get; set; }
     IEnumerable<SDK.Models.Action> GameActions { get; set; } = [];
@@ -126,8 +127,9 @@ else
                 var manifest = await ManifestHelper.ReadAsync<GameManifest>(Game.InstallDirectory, Game.Id);
 
                 if (manifest != null)
-                    actions = manifest.Actions.Where(a => !a.IsPrimaryAction).ToList();
-
+                {
+                    actions = manifest.Actions.Where(a => ShowPrimaryActions || !a.IsPrimaryAction).ToList();
+                }
             }
 
             GameActions = actions;

--- a/LANCommander.Launcher/UI/Library/Components/LibraryListItem.razor
+++ b/LANCommander.Launcher/UI/Library/Components/LibraryListItem.razor
@@ -2,8 +2,8 @@
 
 <Dropdown Trigger="new Trigger[] { Trigger.ContextMenu }" Style="display: block; width: 100%;">
     <Overlay>
-        <Menu>
-            <LibraryItemContextMenu Model="Model" />
+        <Menu Class="library-context">
+            <LibraryItemContextMenu Model="Model" ShowPrimaryActions="true" />
         </Menu>
     </Overlay>
     <ChildContent>

--- a/LANCommander.Launcher/UI/Library/Components/LibraryListItem.razor
+++ b/LANCommander.Launcher/UI/Library/Components/LibraryListItem.razor
@@ -2,7 +2,7 @@
 
 <Dropdown Trigger="new Trigger[] { Trigger.ContextMenu }" Style="display: block; width: 100%;">
     <Overlay>
-        <Menu Class="library-context">
+        <Menu Class="library-context" Selectable="false">
             <LibraryItemContextMenu Model="Model" ShowPrimaryActions="true" />
         </Menu>
     </Overlay>


### PR DESCRIPTION
Fixes the issue of context menu items not triggering on click for game actions

Issues:
- Context menu lists game actions, but clicking on these won't do anything (see #302)

Changes: 
- Adds primary actions on context menu for library list
- Play-button context menu keeps listing only non-primary actions
- Fixes #302

Image showing context menu including primary action (+ play-button context menu):
![Fix](https://github.com/user-attachments/assets/4226738b-1189-41d3-bcc6-df5c08d5afac)
