### PR TITLE
[Launcher] Rework on offline mode and connection timeout

### DIFF
--- a/LANCommander.Launcher.Models/ConnectionState.cs
+++ b/LANCommander.Launcher.Models/ConnectionState.cs
@@ -5,4 +5,5 @@ public class ConnectionState
     public bool ValidCredentials { get; set; }
     public bool IsConnected { get; set; }
     public bool OfflineModeEnabled { get; set; }
+    public bool IsStartup { get; set; }
 }

--- a/LANCommander.Launcher.Services/AuthenticationService.cs
+++ b/LANCommander.Launcher.Services/AuthenticationService.cs
@@ -180,7 +180,7 @@ public class AuthenticationService : BaseService
         if (decodedToken == null)
             return String.Empty;
 
-        return decodedToken.Claims.First(claim => claim.Type == ClaimTypes.Name).Value;
+        return decodedToken.Claims?.FirstOrDefault(claim => claim.Type == ClaimTypes.Name)?.Value ?? string.Empty;
     }
 
     public JwtSecurityToken DecodeToken()
@@ -194,7 +194,7 @@ public class AuthenticationService : BaseService
             
             return handler.ReadToken(Settings.Authentication.AccessToken) as JwtSecurityToken;
         }
-        catch (Exception ex)
+        catch
         {
             return null;
         }

--- a/LANCommander.Launcher.Services/AuthenticationService.cs
+++ b/LANCommander.Launcher.Services/AuthenticationService.cs
@@ -137,7 +137,7 @@ public class AuthenticationService : BaseService
 
         Settings.Authentication.OfflineMode = state;
 
-        if (!state)
+        if (state)
             Client.Disconnect();
 
         SettingService.SaveSettings(Settings);

--- a/LANCommander.Launcher.Services/AuthenticationService.cs
+++ b/LANCommander.Launcher.Services/AuthenticationService.cs
@@ -31,6 +31,11 @@ public class AuthenticationService : BaseService
         return Client.IsConnected();
     }
 
+    public string GetServerAddress()
+    {
+        return Client.IsConfigured() ? Client.GetServerAddress() : string.Empty;
+    }
+
     public async Task<bool> IsServerOnlineAsync()
     {
         try
@@ -164,8 +169,11 @@ public class AuthenticationService : BaseService
         TemporarilyOffline = false;
 
         Settings = SettingService.GetSettings();
-        
-        Settings.Authentication = new AuthenticationSettings();
+
+        Settings.Authentication = new AuthenticationSettings
+        {
+            ServerAddress = Settings.Authentication.ServerAddress, // keep server address when logging out
+        };
 
         SettingService.SaveSettings(Settings);
         

--- a/LANCommander.Launcher.Services/Extensions/IServiceProviderExtensions.cs
+++ b/LANCommander.Launcher.Services/Extensions/IServiceProviderExtensions.cs
@@ -24,10 +24,6 @@ namespace LANCommander.Launcher.Services.Extensions
                 var authenticationService = scope.ServiceProvider.GetService<AuthenticationService>();
                 var keepAliveService = scope.ServiceProvider.GetService<KeepAliveService>();
 
-                #region Sign in
-                authenticationService.Login().Wait();
-                #endregion
-
                 #region Scaffold Required Directories
                 try
                 {

--- a/LANCommander.Launcher.Services/KeepAliveService.cs
+++ b/LANCommander.Launcher.Services/KeepAliveService.cs
@@ -19,6 +19,8 @@ public class KeepAliveService : BaseService
     private int MaxRetries = 10;
     private bool ConnectionLost = false;
 
+    private Models.ConnectionState ConnectionState = new();
+
     public event EventHandler ConnectionSevered;
     public event EventHandler ConnectionLostPermanently;
     public event EventHandler ConnectionEstablished;
@@ -42,6 +44,11 @@ public class KeepAliveService : BaseService
         };
 
         ConnectionEstablished += (sender, args) => StartMonitoring();
+    }
+
+    public Models.ConnectionState GetConnectionState()
+    {
+        return ConnectionState;
     }
 
     public void StartMonitoring()

--- a/LANCommander.Launcher.Services/KeepAliveService.cs
+++ b/LANCommander.Launcher.Services/KeepAliveService.cs
@@ -102,12 +102,13 @@ public class KeepAliveService : BaseService
         if (serverOnline && ConnectionLost)
         {
             ConnectionLost = false;
-            
-            RetryConnectionTimer.Stop();
-            RetryConnectionTimer.Elapsed -= RetryConnection;
-            
+
+            RetryConnectionTimer?.Stop();
+            RetryConnectionTimer?.Dispose();
+            RetryConnectionTimer = null;
+
             ConnectionEstablished?.Invoke(this, EventArgs.Empty);
-            
+
             AuthenticationService.SetOfflineMode(false);
         }
         else
@@ -116,11 +117,12 @@ public class KeepAliveService : BaseService
 
             if (RetryCount == MaxRetries)
             {
+                RetryConnectionTimer?.Stop();
+                RetryConnectionTimer?.Dispose();
+                RetryConnectionTimer = null;
+
                 ConnectionLostPermanently?.Invoke(this, EventArgs.Empty);
-                
-                RetryConnectionTimer.Stop();
-                RetryConnectionTimer.Elapsed -= RetryConnection;
-                
+
                 AuthenticationService.SetOfflineMode(true);
             }
         }

--- a/LANCommander.Launcher.Services/KeepAliveService.cs
+++ b/LANCommander.Launcher.Services/KeepAliveService.cs
@@ -54,6 +54,7 @@ public class KeepAliveService : BaseService
     public void StartMonitoring()
     {
         RetryCount = 0;
+        ConnectionLost = false;
 
         CheckConnectionTimer?.Stop();
         CheckConnectionTimer?.Dispose();

--- a/LANCommander.Launcher/UI/Authenticate/Components/AuthenticationStage.cs
+++ b/LANCommander.Launcher/UI/Authenticate/Components/AuthenticationStage.cs
@@ -2,6 +2,7 @@ namespace LANCommander.Launcher.UI.Authenticate.Components;
 
 public enum AuthenticationStage
 {
+    None,
     Login,
     Register,
     SelectServer,

--- a/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
@@ -69,15 +69,14 @@
 
     AuthRequest Model = new();
     bool Loading = false;
+    private string? PreviousServerAddress;
     AuthenticationProviderDialog AuthenticationProviderDialog;
-    
+
     Models.Settings Settings = SettingService.GetSettings();
 
-    protected override async Task OnParametersSetAsync()
+    protected override async Task OnInitializedAsync()
     {
         AuthenticationProviders = new();
-        
-        await Client.ChangeServerAddressAsync(ServerAddress);
 
         try
         {
@@ -90,8 +89,17 @@
         {
             Logger.LogError(ex, "Could not get authentication providers");
         }
-        
+
         StateHasChanged();
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (ServerAddress != PreviousServerAddress)
+        {
+            await Client.ChangeServerAddressAsync(ServerAddress);
+        }
+        PreviousServerAddress = ServerAddress;
     }
 
     async Task OnFinish(EditContext editContext)

--- a/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
@@ -37,14 +37,17 @@
 
     RegistrationRequest Model = new();
     bool Loading = false;
-    
+    private string? PreviousServerAddress;
+
     Models.Settings Settings = SettingService.GetSettings();
 
     protected override async Task OnParametersSetAsync()
     {
-        await Client.ChangeServerAddressAsync(ServerAddress);
-        
-        StateHasChanged();
+        if (ServerAddress != PreviousServerAddress)
+        {
+            await Client.ChangeServerAddressAsync(ServerAddress);
+        }
+        PreviousServerAddress = ServerAddress;
     }
 
     async Task OnFinish(EditContext editContext)

--- a/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
@@ -152,9 +152,11 @@
         }
         catch (OperationCanceledException)
         {
+            // ignore, handled in finally
         }
         finally
         {
+            Client.Beacon.CleanupProbe();
             BeaconActive = false;
             await InvokeAsync(StateHasChanged);
         }

--- a/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
@@ -44,7 +44,16 @@
         <Flex Justify="FlexJustify.Center" Class="load-more">
             @if (BeaconActive)
             {
-                <Button Type="ButtonType.Primary" Loading="true" Disabled>Scanning</Button>
+                <Dropdown Trigger="@(new [] { Trigger.Hover })">
+                    <Overlay>
+                        <Menu>
+                            <MenuItem Key="Cancel" OnClick="CancelBeacon">Cancel</MenuItem>
+                        </Menu>
+                    </Overlay>
+                    <ChildContent>
+                        <Button Type="ButtonType.Primary" Loading="true" Disabled>Scanning</Button>
+                    </ChildContent>
+                </Dropdown>
             }
             else
             {
@@ -57,32 +66,40 @@
 @code {
     [Parameter] public EventCallback<string> OnSelected { get; set; }
     [Parameter] public bool Connecting { get; set; } = false;
-    
+    bool IsInitializing = false;
+
     bool BeaconActive = false;
     bool OfflineModeAvailable = false;
 
     string ServerAddress = String.Empty;
-    
+
     AuthRequest Model = new();
     List<DiscoveredServer> DiscoveredServers = new();
+    private CancellationTokenSource DiscoveryToken = new CancellationTokenSource();
+
     Models.Settings Settings = SettingService.GetSettings();
 
     protected override async Task OnInitializedAsync()
     {
+        IsInitializing = true;
+        Connecting = true;
         OfflineModeAvailable = await AuthenticationService.OfflineModeAvailableAsync();
-        
+
         Client.Beacon.OnBeaconResponse += OnBeaconResponse;
 
         if (!OfflineModeAvailable)
         {
             ActivateBeacon();
         }
+
+        Connecting = false;
+        IsInitializing = false;
     }
 
     private void OnBeaconResponse(object sender, BeaconResponseArgs e)
     {
         var discoveredServer = new DiscoveredServer(e.Message, e.EndPoint);
-        
+
         if (DiscoveredServers.All(s => s.Address != discoveredServer.Address))
             DiscoveredServers.Add(discoveredServer);
     }
@@ -103,18 +120,43 @@
         NavigationManager.NavigateTo("/", forceLoad: true);
     }
 
+    void CancelBeacon()
+    {
+        DiscoveryToken?.Cancel();
+    }
+
     async Task ActivateBeacon()
     {
-        BeaconActive = true;
+        try
+        {
+            BeaconActive = true;
+            await InvokeAsync(StateHasChanged);
 
-        await Client.Beacon.StartProbeAsync();
+            // give the UI a chance to render:
+            await Task.Yield();
 
-        await Task.Delay(10000);
+            if ((DiscoveryToken?.TryReset() ?? false) == false)
+            {
+                DiscoveryToken = new();
+            }
 
-        await Client.Beacon.StopProbeAsync();
-        
-        BeaconActive = false;
+            await Client.Beacon.StartProbeAsync(cancellationToken: DiscoveryToken.Token);
+            await Task.Delay(10000, DiscoveryToken.Token);
+            await Client.Beacon.StopProbeAsync();
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        finally
+        {
+            BeaconActive = false;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
 
-        await InvokeAsync(StateHasChanged);
+    public void Dispose()
+    {
+        DiscoveryToken?.Cancel();
+        DiscoveryToken?.Dispose();
     }
 }

--- a/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
@@ -82,6 +82,12 @@
     protected override async Task OnInitializedAsync()
     {
         IsInitializing = true;
+
+        if (Client.IsConfigured())
+        {
+            ServerAddress = Client.GetServerAddress() ?? string.Empty;
+        }
+
         Connecting = true;
         OfflineModeAvailable = await AuthenticationService.OfflineModeAvailableAsync();
 

--- a/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
@@ -12,10 +12,21 @@
 </PageHeader>
 
 <Form Model="Model" OnFinish="() => SelectServer(ServerAddress)">
+
+    @if (OfflineModeAvailable)
+    {
+        <Alert Message="The server appears to be offline. Please try reconnecting or use offline mode." Type="AlertType.Warning" ShowIcon="true" Style="margin-bottom: 16px;" />
+    }
+
     <FormItem>
         <Flex Gap="FlexGap.Small">
             <Input @bind-Value="ServerAddress" Placeholder="Server Address" AutoFocus Disabled="Connecting" />
             <Button Type="ButtonType.Primary" HtmlType="submit" Disabled="Connecting" Loading="Connecting">Connect</Button>
+
+            @if (OfflineModeAvailable)
+            {
+                <Button OnClick="() => OfflineMode()">Offline</Button>
+            }
         </Flex>
     </FormItem>
 </Form>
@@ -61,8 +72,11 @@
         OfflineModeAvailable = await AuthenticationService.OfflineModeAvailableAsync();
         
         Client.Beacon.OnBeaconResponse += OnBeaconResponse;
-        
-        ActivateBeacon();
+
+        if (!OfflineModeAvailable)
+        {
+            ActivateBeacon();
+        }
     }
 
     private void OnBeaconResponse(object sender, BeaconResponseArgs e)
@@ -82,7 +96,13 @@
         if (OnSelected.HasDelegate)
             await OnSelected.InvokeAsync(serverAddress);
     }
-    
+
+    void OfflineMode()
+    {
+        AuthenticationService.LoginOffline();
+        NavigationManager.NavigateTo("/", forceLoad: true);
+    }
+
     async Task ActivateBeacon()
     {
         BeaconActive = true;

--- a/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
@@ -8,7 +8,7 @@
     {
         @Authenticated
     }
-    else
+    else if (!IsValidating)
     {
         @NotAuthenticated
     }
@@ -19,6 +19,7 @@
     [Parameter] public RenderFragment NotAuthenticated { get; set; }
 
     private ConnectionState ConnectionState = default!;
+    private bool IsValidating = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -38,8 +39,16 @@
 
     public async Task Validate()
     {
-        ConnectionState.IsConnected = await AuthenticationService.ValidateConnectionAsync();
-        ConnectionState.OfflineModeEnabled = AuthenticationService.OfflineModeEnabled();
+        try
+        {
+            IsValidating = true;
+            ConnectionState.IsConnected = await AuthenticationService.ValidateConnectionAsync();
+            ConnectionState.OfflineModeEnabled = AuthenticationService.OfflineModeEnabled();
+        }
+        finally
+        {
+            IsValidating = false;
+        }
 
         await InvokeAsync(StateHasChanged);
     }

--- a/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
@@ -1,6 +1,7 @@
 @using ConnectionState = LANCommander.Launcher.Models.ConnectionState
 @inject AuthenticationService AuthenticationService
 @inject NavigationManager NavigationManager
+@inject KeepAliveService KeepAliveService
 
 <CascadingValue Value="ConnectionState">
     @if (ConnectionState.IsConnected || ConnectionState.OfflineModeEnabled)
@@ -17,10 +18,12 @@
     [Parameter] public RenderFragment Authenticated { get; set; }
     [Parameter] public RenderFragment NotAuthenticated { get; set; }
 
-    public ConnectionState ConnectionState = new();
+    private ConnectionState ConnectionState = default!;
 
     protected override async Task OnInitializedAsync()
     {
+        ConnectionState = KeepAliveService.GetConnectionState();
+
         AuthenticationService.OnLogin += async (sender, args) =>
         {
             await Validate();

--- a/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticatedView.razor
@@ -17,6 +17,7 @@
 @code {
     [Parameter] public RenderFragment Authenticated { get; set; }
     [Parameter] public RenderFragment NotAuthenticated { get; set; }
+    [Parameter] public bool NoAutoValidate { get; set; }
 
     private ConnectionState ConnectionState = default!;
     private bool IsValidating = false;
@@ -34,7 +35,8 @@
             await Validate();
         };
 
-        await Validate();
+        if (!NoAutoValidate)
+            await Validate();
     }
 
     public async Task Validate()

--- a/LANCommander.Launcher/UI/Components/AuthenticationForm.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticationForm.razor
@@ -6,6 +6,7 @@
 @inject ProfileService ProfileService
 @inject NavigationManager NavigationManager
 @inject SDK.Client Client
+@inject AuthenticationService AuthenticationService
 @inject IMessageService MessageService
 @inject ILogger<System.Index> Logger
 
@@ -37,17 +38,38 @@
 </CascadingValue>
 
 @code {
+    [CascadingParameter] public Models.ConnectionState ConnectionState { get; set; }
+
     AuthenticationFormState State { get; set; }
 
     bool _connecting { get; set; } = false;
 
-    protected override void OnInitialized()
+    private Models.Settings Settings = SettingService.GetSettings();
+
+    protected override async Task OnInitializedAsync()
     {
+        await base.OnInitializedAsync();
+
         State = new()
         {
-            Stage = AuthenticationStage.SelectServer,
-            ServerAddress = String.Empty,
+            Stage = AuthenticationStage.None,
+            ServerAddress = AuthenticationService.GetServerAddress(),
         };
+
+        bool hasServer = await AuthenticationService.IsServerOnlineAsync();
+        if (hasServer)
+        {
+            if (!ConnectionState.IsStartup)
+            {
+                State.Stage = AuthenticationService.HasStoredCredentials() || Settings.LaunchCount > 0
+                    ? AuthenticationStage.Login
+                    : AuthenticationStage.Register;
+            }
+        }
+        else
+        {
+            State.Stage = AuthenticationStage.SelectServer;
+        }
     }
 
     async Task ServerSelected(string serverAddress)

--- a/LANCommander.Launcher/UI/Components/Footer.razor
+++ b/LANCommander.Launcher/UI/Components/Footer.razor
@@ -13,7 +13,7 @@
         }
         else
         {
-            if (Client.Settings.EnableUserLibraries)
+            if (Client.Settings?.EnableUserLibraries ?? false)
             {
                 <ConnectionStateView>
                     <Online>
@@ -29,16 +29,25 @@
         }
     </div>
 
-    @if (InstallService.Queue.Any(qi => qi.State))
-    {
-        <div class="downloader" @onclick="() => ShowDownloadQueue()" style="flex-shrink: 0;">
-            <CurrentDownloadItem ShowIcon="true"/>
-        </div>
-    }
-    else
-    {
-        <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" OnClick="() => ShowDownloadQueue()">Downloads</Button>
-    }
+    <ConnectionStateView>
+        <Online>
+            @if (InstallService.Queue.Any(qi => qi.State))
+            {
+                <div class="downloader" @onclick="() => ShowDownloadQueue()" style="flex-shrink: 0;">
+                    <CurrentDownloadItem ShowIcon="true"/>
+                </div>
+            }
+            else
+            {
+                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" OnClick="() => ShowDownloadQueue()">Downloads</Button>
+            }
+        </Online>
+        <Offline>
+            <Tooltip Title="You are currently offline" Placement="Placement.TopLeft">
+                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" Disabled>Downloads</Button>
+            </Tooltip>
+        </Offline>
+    </ConnectionStateView>
 
     <div style="flex: 1; text-align:  right;">
         <Tooltip Title="Coming soon!" Placement="Placement.TopRight">
@@ -51,7 +60,7 @@
 
 @code {
     [CascadingParameter] public bool Connected { get; set; }
-    
+
     bool DownloadQueueVisible = false;
 
     DownloadQueue DownloadQueue;

--- a/LANCommander.Launcher/UI/Components/ImportHandler.razor
+++ b/LANCommander.Launcher/UI/Components/ImportHandler.razor
@@ -1,0 +1,126 @@
+@using LANCommander.Launcher.Models
+@implements IDisposable
+@inject ImportManagerService ImportManagerService
+@inject ImportService ImportService
+@inject IMessageService MessageService
+@inject ILogger<ImportHandler> Logger
+
+@code 
+{
+    [Parameter] public EventCallback<ImportProgressEventArgs> Progress { get; set; }
+
+    public bool Importing;
+    int ImportStatusIndex = 0;
+    int ImportStatusTotal = 0;
+
+    protected override void OnInitialized()
+    {
+        ImportManagerService.OnImportRequested += Import;
+    }
+
+    public void Dispose()
+    {
+        if (ImportManagerService != null)
+        {
+            ImportManagerService.OnImportRequested -= Import;
+        }
+
+        if (ImportService != null)
+        {
+            // Clear any existing handlers
+            ImportService.OnImportComplete -= OnImportCompleteHandler;
+            ImportService.OnImportFailed -= OnImportFailedHandler;
+            ImportService.OnImportUpdated -= OnImportUpdatedHandler;
+        }
+    }
+
+    public async Task Import()
+    {
+        if (!Importing)
+        {
+            Logger?.LogInformation("Starting import process");
+
+            // Clear any existing handlers
+            ImportService.OnImportComplete -= OnImportCompleteHandler;
+            ImportService.OnImportFailed -= OnImportFailedHandler;
+            ImportService.OnImportUpdated -= OnImportUpdatedHandler;
+
+            // Add our handlers
+            ImportService.OnImportComplete += OnImportCompleteHandler;
+            ImportService.OnImportFailed += OnImportFailedHandler;
+            ImportService.OnImportUpdated += OnImportUpdatedHandler;
+
+            // Now start the import process
+            Importing = true;
+            ImportStatusIndex = 0;
+            ImportStatusTotal = 0;
+            await NotifyProgress(ImportProgressState.Importing);
+
+            await InvokeAsync(StateHasChanged);
+            MessageService.Info("Import Started", 2.5);
+
+            Logger?.LogInformation("Starting import");
+            await ImportService.ImportLibraryAsync(); // Call directly instead of using JS
+        }
+    }
+
+    private async Task NotifyProgress(ImportProgressState state)
+    {
+        if (!Progress.HasDelegate)
+            return;
+
+        await Progress.InvokeAsync(new ImportProgressEventArgs
+        {
+            State = state,
+            Index = ImportStatusIndex,
+            Total = ImportStatusTotal,
+        });
+    }
+
+    private async Task OnImportCompleteHandler()
+    {
+        Logger?.LogInformation("Import Complete handler called");
+        Importing = false;
+        ImportStatusIndex = 0;
+        ImportStatusTotal = 0;
+
+        await NotifyProgress(ImportProgressState.Imported);
+        MessageService.Success("Import Complete", 3);
+    }
+
+    private async Task OnImportFailedHandler(Exception ex)
+    {
+        Importing = false;
+        ImportStatusIndex = 0;
+        ImportStatusTotal = 0;
+
+        await NotifyProgress(ImportProgressState.Failed);
+        MessageService.Error("Import Failed", 3);
+    }
+
+    private async Task OnImportUpdatedHandler(ImportStatusUpdate status)
+    {
+        Logger?.LogInformation("Import Update handler called: {Index}/{Total}", status.Index, status.Total);
+        ImportStatusIndex = status.Index;
+        ImportStatusTotal = status.Total;
+
+        await NotifyProgress(ImportProgressState.Updated);
+    }
+
+    public enum ImportProgressState
+    {
+        None = 0,
+        Importing,
+        Updated,
+        Imported,
+        Failed,
+    }
+
+    public class ImportProgressEventArgs
+    {
+        public int Index { get; set; } = 0;
+        public int Total { get; set; } = 0;
+        public ImportProgressState State { get; set; } = ImportProgressState.None;
+        public bool IsActive => State > ImportProgressState.None && State < ImportProgressState.Imported;
+    }
+}

--- a/LANCommander.Launcher/UI/Components/KeepAliveContainer.razor
+++ b/LANCommander.Launcher/UI/Components/KeepAliveContainer.razor
@@ -8,6 +8,7 @@
     protected override void OnInitialized()
     {
         KeepAliveService.ConnectionSevered += OnConnectionSevered;
+        KeepAliveService.ConnectionRetryNext += OnConnectionRetryNext;
         KeepAliveService.ConnectionLostPermanently += OnConnectionLostPermanently;
         KeepAliveService.ConnectionEstablished += OnConnectionEstablished;
     }
@@ -19,6 +20,21 @@
             Key = ConnectionMessageKey,
             Type = MessageType.Loading,
             Content = "Lost connection, retrying...",
+            Duration = 0,
+        };
+
+        MessageService.Open(messageConfig);
+    }
+
+    void OnConnectionRetryNext(object? sender, EventArgs e)
+    {
+        // show same lost-connection-message by replacing the message by its key
+        var retry = KeepAliveService.GetRetryCount();
+        var messageConfig = new MessageConfig
+        {
+            Key = ConnectionMessageKey,
+            Type = MessageType.Loading,
+            Content = $"Lost connection, retrying ({retry.current}/{retry.total}) ...",
             Duration = 0,
         };
 
@@ -54,6 +70,7 @@
     public void Dispose()
     {
         KeepAliveService.ConnectionSevered -= OnConnectionSevered;
+        KeepAliveService.ConnectionRetryNext -= OnConnectionRetryNext;
         KeepAliveService.ConnectionLostPermanently -= OnConnectionLostPermanently;
         KeepAliveService.ConnectionEstablished -= OnConnectionEstablished;
     }

--- a/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
@@ -37,13 +37,13 @@
         <MenuDivider />
     }
 
-    <MenuItem OnClick="() => OpenSaveManager()">
+    <MenuItem OnClick="() => OpenSaveManager()" Disabled="ConnectionState.OfflineModeEnabled">
         Manage Saves
     </MenuItem>
 
     if (Settings.Games.InstallDirectories.Length > 1 || Game.DependentGames.Any(g => g.Type == Data.Enums.GameType.Expansion || g.Type == Data.Enums.GameType.Mod))
     {
-        <MenuItem OnClick="() => Modify()">
+        <MenuItem OnClick="() => Modify()" Disabled="ConnectionState.OfflineModeEnabled">
             Modify
         </MenuItem>
     }
@@ -51,10 +51,10 @@
     <MenuItem OnClick="() => BrowseFiles()">
         Browse Files
     </MenuItem>
-    <MenuItem OnClick="() => ValidateFiles()">
+    <MenuItem OnClick="() => ValidateFiles()" Disabled="ConnectionState.OfflineModeEnabled">
         Validate Files
     </MenuItem>
-    <MenuItem OnClick="() => RemoveFromLibrary()">
+    <MenuItem OnClick="() => RemoveFromLibrary()" Disabled="ConnectionState.OfflineModeEnabled">
         Remove
     </MenuItem>
     <MenuItem OnClick="() => Uninstall()">
@@ -63,10 +63,10 @@
 }
 else
 {
-    <MenuItem OnClick="() => Install()">
+    <MenuItem OnClick="() => Install()" Disabled="ConnectionState.OfflineModeEnabled">
         Install
     </MenuItem>
-    <MenuItem OnClick="() => RemoveFromLibrary()">
+    <MenuItem OnClick="() => RemoveFromLibrary()" Disabled="ConnectionState.OfflineModeEnabled">
         Remove
     </MenuItem>
 }
@@ -94,7 +94,7 @@ else
 
 <MenuDivider />
 
-<MenuItem OnClick="() => ReportIssue()">
+<MenuItem OnClick="() => ReportIssue()" Disabled="ConnectionState.OfflineModeEnabled">
     Report Issue
 </MenuItem>
 
@@ -103,6 +103,7 @@ else
 @code {
     [Parameter] public Models.ListItem Model { get; set; }
     [Parameter] public RenderFragment MenuExtra { get; set; }
+    [CascadingParameter] public ConnectionState ConnectionState { get; set; }
 
     Data.Models.Game Game { get; set; }
     IEnumerable<SDK.Models.Action> GameActions { get; set; }

--- a/LANCommander.Launcher/UI/Components/ProfileButton.razor
+++ b/LANCommander.Launcher/UI/Components/ProfileButton.razor
@@ -23,12 +23,9 @@
                 </MenuItem>
             }
 
-            @if (!ConnectionState.OfflineModeEnabled)
-            {
-                <MenuItem OnClick="Logout">
-                    Logout
-                </MenuItem>
-            }
+            <MenuItem OnClick="Logout">
+                Logout
+            </MenuItem>
         </Menu>
     </Overlay>
 

--- a/LANCommander.Launcher/UI/Components/ProfileButton.razor
+++ b/LANCommander.Launcher/UI/Components/ProfileButton.razor
@@ -16,6 +16,13 @@
                 Settings
             </MenuItem>
 
+            @if (!Settings.Authentication.OfflineMode)
+            {
+                <MenuItem OnClick="SwitchToOfflineMode">
+                    Switch to offline mode
+                </MenuItem>
+            }
+
             @if (!ConnectionState.OfflineModeEnabled)
             {
                 <MenuItem OnClick="Logout">
@@ -39,7 +46,7 @@
 
 @code {
     [CascadingParameter] public ConnectionState ConnectionState { get; set; }
-    Models.Settings Settings = null;
+    Models.Settings Settings = SettingService.GetSettings();
 
     User User;
     Guid AvatarId = Guid.Empty;
@@ -96,5 +103,12 @@
         await AuthenticationService.Logout();
 
         NavigationManager.NavigateTo("/Authenticate");
+    }
+
+    void SwitchToOfflineMode()
+    {
+        AuthenticationService.SetOfflineMode(true);
+
+        NavigationManager.NavigateTo("/", forceLoad: true);
     }
 }

--- a/LANCommander.Launcher/UI/Components/ProfileButton.razor
+++ b/LANCommander.Launcher/UI/Components/ProfileButton.razor
@@ -54,8 +54,16 @@
             AvatarId = User?.Avatar?.Id ?? Guid.Empty;
             Alias = String.IsNullOrWhiteSpace(User?.Alias) ? User?.UserName ?? Settings.DEFAULT_GAME_USERNAME : User.Alias;
         };
-        
-        await ProfileService.DownloadProfileInfoAsync();
+
+        if (ConnectionState.OfflineModeEnabled)
+        {
+            string userName = AuthenticationService.GetCurrentUserName();
+            Alias = string.IsNullOrEmpty(userName) ? Alias : userName;
+        }
+        else
+        {
+            await ProfileService.DownloadProfileInfoAsync();
+        }
     }
     
 

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -19,7 +19,7 @@
     <CustomWindow HeaderHeight="37">
         <HeaderExtraControlsLayout>
             <Space Direction="SpaceDirection.Horizontal">
-                <AuthenticatedView>
+                <AuthenticatedView NoAutoValidate="true">
                     <Authenticated>
                         <SpaceItem>
                             @if (ImportStatus.IsActive)
@@ -55,7 +55,7 @@
                             <ProfileButton/>
                         </SpaceItem>
                     </Authenticated>
-                    
+
                     <NotAuthenticated>
                         <SpaceItem>
                             <Button Type="@ButtonType.Text" Icon="@IconType.Outline.CloudSync" OnClick="Connect" Loading="@Connecting" Danger/>
@@ -67,7 +67,7 @@
         <WindowContent>
             <ErrorHandler Title="Launcher Crashed">
                 <Body>
-                    <AuthenticatedView>
+                    <AuthenticatedView NoAutoValidate="false">
                         <Authenticated>
                             @Body
 
@@ -158,11 +158,13 @@
 
         if (await LANCommander.ValidateTokenAsync(token))
         {
+            ConnectionState.IsStartup = true;
             await AuthenticationService.Login();
             await ProfileService.DownloadProfileInfoAsync();
 
             ConnectionState.IsConnected = true;
             ConnectionState.OfflineModeEnabled = false;
+            ConnectionState.IsStartup = false;
 
             await ImportManagerService.RequestImport();
             await InvokeAsync(StateHasChanged);

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -43,7 +43,7 @@
                                     <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@ImportHandler.Import"/>
                                 </Tooltip>
                             }
-                            else
+                            else if (!string.IsNullOrEmpty(Settings.Authentication.AccessToken))
                             {
                                 <Tooltip Title="Reconnect to server" MouseEnterDelay="0.5">
                                     <Button Type="@ButtonType.Text" Icon="@IconType.Outline.CloudSync" OnClick="Connect" Loading="@Connecting" Danger/>

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -7,6 +7,7 @@
 @inject ImportService ImportService
 @inject ProfileService ProfileService
 @inject AuthenticationService AuthenticationService
+@inject KeepAliveService KeepAliveService
 @inject IMessageService MessageService
 @inject NavigationManager NavigationManager
 @inject ModalService ModalService
@@ -100,7 +101,7 @@
     public bool Importing;
     public bool Connecting;
 
-    public ConnectionState ConnectionState = new();
+    public ConnectionState ConnectionState = default!;
 
     public IMessageService Messages { get; set; }
 
@@ -144,6 +145,7 @@
     protected override async Task OnInitializedAsync()
     {
         Settings = SettingService.GetSettings();
+        ConnectionState = KeepAliveService.GetConnectionState();
         Messages = MessageService;
 
         AuthenticationService.OnOfflineModeChanged += OnOfflineModeChanged;

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -164,6 +164,7 @@
             ConnectionState.IsConnected = true;
             ConnectionState.OfflineModeEnabled = false;
 
+            await ImportManagerService.RequestImport();
             await InvokeAsync(StateHasChanged);
         }
 

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -21,16 +21,16 @@
                 <AuthenticatedView>
                     <Authenticated>
                         <SpaceItem>
-                            @if (Importing)
+                            @if (ImportStatus.IsActive)
                             {
                                 <Popover Placement="Placement.BottomRight" IsButton Trigger="new[] { Trigger.Hover }">
                                     <ChildContent>
-                                        <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" Loading="@Importing"/>
+                                        <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" Loading="true"/>
                                     </ChildContent>
                                     <ContentTemplate>
                                         <ImportProgressDisplay 
-                                            Index="@ImportStatusIndex" 
-                                            Total="@ImportStatusTotal" 
+                                            Index="@ImportStatus.Index" 
+                                            Total="@ImportStatus.Total" 
                                             CurrentItem="@(_importProgress?.CurrentItem)" 
                                         />
                                     </ContentTemplate>
@@ -39,7 +39,7 @@
                             else if (ConnectionState.IsConnected)
                             {
                                 <Tooltip Title="Re-import library" MouseEnterDelay="0.5">
-                                    <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@Import"/>
+                                    <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@ImportHandler.Import"/>
                                 </Tooltip>
                             }
                             else
@@ -82,10 +82,11 @@
                         </NotAuthenticated>
                     </AuthenticatedView>
 
+                    <ImportHandler @ref="ImportHandler" Progress="OnImportProcess" />
                     <UpdateChecker/>
                     <AntContainer/>
                 </Body>
-                
+
                 <Extra>
                     <Button Type="ButtonType.Primary" OnClick="@(() => NavigationManager.NavigateTo("/", true))">View Library</Button>
                 </Extra>
@@ -100,11 +101,15 @@
     public bool Connecting;
 
     public ConnectionState ConnectionState = new();
-    
+
     public IMessageService Messages { get; set; }
 
+    ImportHandler ImportHandler;
+    ImportHandler.ImportProgressEventArgs ImportStatus = new();
+    private ImportProgress _importProgress => ImportService.Progress;
+
     string RandomQuip = "";
-    
+
     string[] CrashQuips = new[]
     {
         "You Died.",
@@ -136,38 +141,30 @@
         "Damn, those alien bastards are gonna pay for shooting up my ride"
     };
 
-    int ImportStatusIndex = 0;
-    int ImportStatusTotal = 0;
-
-    private ImportProgress _importProgress => ImportService.Progress;
-
     protected override async Task OnInitializedAsync()
     {
         Settings = SettingService.GetSettings();
         Messages = MessageService;
 
-        ImportManagerService.OnImportRequested += Import;
         AuthenticationService.OnOfflineModeChanged += OnOfflineModeChanged;
-        
-        Settings = SettingService.GetSettings();
 
         var token = new SDK.Models.AuthToken
         {
             AccessToken = Settings.Authentication.AccessToken,
             RefreshToken = Settings.Authentication.RefreshToken
         };
-        
+
         if (await LANCommander.ValidateTokenAsync(token))
         {
             await AuthenticationService.Login();
             await ProfileService.DownloadProfileInfoAsync();
-            
+
             ConnectionState.IsConnected = true;
             ConnectionState.OfflineModeEnabled = false;
 
             await InvokeAsync(StateHasChanged);
         }
-    
+
         var randIndex = new Random().Next(0, CrashQuips.Length - 1);
         RandomQuip = CrashQuips[randIndex];
     }
@@ -178,23 +175,18 @@
         {
             AuthenticationService.OnOfflineModeChanged -= OnOfflineModeChanged;
         }
-
-        if (ImportService != null)
-        {
-            ImportService.OnImportComplete -= OnImportCompleteHandler;
-            ImportService.OnImportUpdated -= OnImportUpdatedHandler;
-        }
-
-        if (ImportManagerService != null)
-        {
-            ImportManagerService.OnImportRequested -= Import;
-        }
     }
 
     async void OnOfflineModeChanged(bool state)
     {
         ConnectionState.OfflineModeEnabled = state;
         ConnectionState.IsConnected = LANCommander.IsConnected();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    async void OnImportProcess(ImportHandler.ImportProgressEventArgs importProgress)
+    {
+        ImportStatus = importProgress;
         await InvokeAsync(StateHasChanged);
     }
 
@@ -223,7 +215,7 @@
             await ProfileService.DownloadProfileInfoAsync();
 
             MessageService.Success("Back Online!");
-            
+
             ConnectionState.IsConnected = true;
             ConnectionState.OfflineModeEnabled = false;
 
@@ -260,67 +252,13 @@
     async Task Logout()
     {
         await AuthenticationService.Logout();
-        
+
         ConnectionState.IsConnected = false;
         ConnectionState.OfflineModeEnabled = false;
 
         NavigationManager.NavigateTo("/Authenticate");
     }
 
-    public async Task Import()
-    {
-        if (!Importing)
-        {
-            Logger?.LogInformation("Starting import process");
-
-            // Clear any existing handlers
-            ImportService.OnImportComplete -= OnImportCompleteHandler;
-            ImportService.OnImportUpdated -= OnImportUpdatedHandler;
-
-            // Add our handlers
-            ImportService.OnImportComplete += OnImportCompleteHandler;
-            ImportService.OnImportFailed += OnImportFailedHandler;
-            ImportService.OnImportUpdated += OnImportUpdatedHandler;
-
-            // Now start the import process
-            Importing = true;
-            ImportStatusIndex = 0;
-            ImportStatusTotal = 0;
-            await InvokeAsync(StateHasChanged);
-            MessageService.Info("Import Started", 2.5);
-
-            Logger?.LogInformation("Starting import");
-            await ImportService.ImportLibraryAsync(); // Call directly instead of using JS
-        }
-    }
-
-    private async Task OnImportCompleteHandler()
-    {
-        Logger?.LogInformation("Import Complete handler called");
-        Importing = false;
-        ImportStatusIndex = 0;
-        ImportStatusTotal = 0;
-        MessageService.Success("Import Complete", 3);
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task OnImportFailedHandler(Exception ex)
-    {
-        Importing = false;
-        ImportStatusIndex = 0;
-        ImportStatusTotal = 0;
-        MessageService.Error("Import Failed", 3);
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task OnImportUpdatedHandler(ImportStatusUpdate status)
-    {
-        Logger?.LogInformation("Import Update handler called: {Index}/{Total}", 
-            status.Index, status.Total);
-        ImportStatusIndex = status.Index;
-        ImportStatusTotal = status.Total;
-        await InvokeAsync(StateHasChanged);
-    }
 }
 
 <style>

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -36,9 +36,17 @@
                                     </ContentTemplate>
                                 </Popover>
                             }
-                            else 
+                            else if (ConnectionState.IsConnected)
                             {
-                                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@Import"/>
+                                <Tooltip Title="Re-import library" MouseEnterDelay="0.5">
+                                    <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@Import"/>
+                                </Tooltip>
+                            }
+                            else
+                            {
+                                <Tooltip Title="Reconnect to server" MouseEnterDelay="0.5">
+                                    <Button Type="@ButtonType.Text" Icon="@IconType.Outline.CloudSync" OnClick="Connect" Loading="@Connecting" Danger/>
+                                </Tooltip>
                             }
                         </SpaceItem>
 

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -812,8 +812,10 @@ namespace LANCommander.SDK
             {
                 var guid = Guid.NewGuid().ToString();
                 var request = new RestRequest("/api/Ping", Method.Head);
-                
                 request.AddHeader("X-Ping", guid);
+
+                // specify timeout for ping response
+                request.Timeout = TimeSpan.FromSeconds(4);
 
                 var response = await ApiClient.ExecuteAsync(request);
 
@@ -843,6 +845,9 @@ namespace LANCommander.SDK
             var request = new RestRequest("/api/Auth/Validate")
                 .AddHeader("Authorization", $"Bearer {Token.AccessToken}")
                 .AddHeader("X-API-Version", GetCurrentVersion().ToString());
+
+            // specify timeout for auth response
+            request.Timeout = TimeSpan.FromSeconds(8);
 
             if (!ignoreVersion && !IgnoreVersion)
                 request.Interceptors = new List<Interceptor>() { new VersionInterceptor() };
@@ -894,6 +899,9 @@ namespace LANCommander.SDK
             var request = new RestRequest("/api/Auth/Validate")
                 .AddHeader("Authorization", $"Bearer {token.AccessToken}")
                 .AddHeader("X-API-Version", GetCurrentVersion().ToString());
+
+            // specify timeout for auth response
+            request.Timeout = TimeSpan.FromSeconds(8);
 
             if (!ignoreVersion && !IgnoreVersion)
                 request.Interceptors = new List<Interceptor>() { new VersionInterceptor() };

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -193,6 +193,12 @@ namespace LANCommander.SDK
             {
                 var urisToTry = baseUrl.SuggestValidUris();
 
+                // if url is fully qualified, limit specific urls
+                if (Uri.TryCreate(baseUrl, UriKind.RelativeOrAbsolute, out var baseUri) && baseUrl.Contains(':'))
+                {
+                    urisToTry = urisToTry.Take(baseUri.IsAbsoluteUri ? 1 : 2);
+                }
+
                 foreach (var uri in urisToTry)
                 {
                     Logger?.LogInformation("Attempting to find server at {ServerAddress}", uri.ToString());

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -221,6 +221,11 @@ namespace LANCommander.SDK
             }
         }
 
+        public bool IsConfigured()
+        {
+            return ApiClient != null && !string.IsNullOrWhiteSpace(BaseUrl?.ToString());
+        }
+
         public bool IsConnected()
         {
             return Connected;

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -194,9 +194,13 @@ namespace LANCommander.SDK
                 var urisToTry = baseUrl.SuggestValidUris();
 
                 // if url is fully qualified, limit specific urls
-                if (Uri.TryCreate(baseUrl, UriKind.RelativeOrAbsolute, out var baseUri) && baseUrl.Contains(':'))
+                if (Uri.TryCreate(baseUrl, UriKind.RelativeOrAbsolute, out var baseUri))
                 {
-                    urisToTry = urisToTry.Take(baseUri.IsAbsoluteUri ? 1 : 2);
+                    var hasPort = baseUrl.Replace(Uri.SchemeDelimiter, "").Contains(':');
+                    if (hasPort)
+                    {
+                        urisToTry = urisToTry.Take(baseUri.IsAbsoluteUri ? 1 : 2);
+                    }
                 }
 
                 foreach (var uri in urisToTry)

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -90,7 +90,7 @@ namespace LANCommander.SDK
 
             try
             {
-                ChangeServerAddressAsync(baseUrl).Wait();
+                ConfigureServerAddress(baseUrl);
             }
             catch
             {
@@ -101,7 +101,7 @@ namespace LANCommander.SDK
         {
             try
             {
-                ChangeServerAddressAsync(baseUrl).Wait();
+                ConfigureServerAddress(baseUrl);
             }
             catch
             {
@@ -155,6 +155,36 @@ namespace LANCommander.SDK
             IgnoreVersion = true;
 
             BaseCmdlet.Client = this;
+        }
+
+        public void ConfigureServerAddress(string baseUrl)
+        {
+            if (!String.IsNullOrWhiteSpace(baseUrl))
+            {
+                var urisToTry = baseUrl.SuggestValidUris();
+
+                foreach (var uri in urisToTry)
+                {
+                    Logger?.LogInformation("Attempting to configure server at {ServerAddress}", uri.ToString());
+
+                    try
+                    {
+                        ApiClient = new RestClient(uri);
+                        BaseUrl = uri;
+
+                        // Successful! Found our service
+                        Logger?.LogInformation("Using server address {ServerAddress}", uri.ToString());
+
+                        return;
+                    }
+                    catch
+                    {
+                        Logger?.LogError("Could not configure server at {ServerAddress}", uri.ToString());
+                    }
+                }
+
+                throw new Exception("Could not configure a server at that address");
+            }
         }
 
         public async Task ChangeServerAddressAsync(string baseUrl)

--- a/LANCommander.SDK/Services/DiscoveryProbe.cs
+++ b/LANCommander.SDK/Services/DiscoveryProbe.cs
@@ -16,7 +16,8 @@ namespace LANCommander.SDK.Services;
 public class DiscoveryProbe : IDisposable
 {
     private const int BufferSize = 1024;
-    
+
+    private bool _disposed = false;
     private int _port = 35891;
     private readonly UdpClient _udpClient;
     private readonly Socket _socket;
@@ -76,7 +77,7 @@ public class DiscoveryProbe : IDisposable
             _socket.Bind(new IPEndPoint(addressInformation.Address, _port));
             _socket.BeginReceiveFrom(_buffer, 0, _buffer.Length, SocketFlags.None, ref fromEndpoint, ReceiveCallback, null);
         }
-        catch (SocketException ex)
+        catch (SocketException)
         {
             throw;
         }
@@ -115,18 +116,23 @@ public class DiscoveryProbe : IDisposable
         {
             // Socket closed
         }
-        catch (Exception ex)
+        catch (Exception)
         {
             // Log error
         }
     }
 
+    public bool IsDisposed => _disposed;
+
     public void Dispose()
     {
+        OnBeaconResponse = null;
+
         _udpClient?.Close();
         _udpClient?.Dispose();
         _socket?.Close();
         _socket?.Dispose();
         _cancellationTokenSource?.Dispose();
+        _disposed = true;
     }
 }


### PR DESCRIPTION
## Adds back offline mode, faster server connection check and more

Issues before:
- Starting Launcher with server down does not show UI/window
- Attempting connection on server address including port will try every combination of possible server address
- Importing games is called multiple times if logging out and in again


This PR includes the following:
- Starts Launcher without attempting login/auth, only after UI is loaded
- Reducing timeout for ping and auth
- Fixes offline login, allowing to login and start games with no server connection
- Permanent offline mode when logged in
- Reads username from previous login (token)
- Fixes several UI elements in offline mode (such as library context menu)
- Restores server address in UI for validating server connection
- Fixes server discovery after a failed connection
- Reduces the number of ping attempts in login/register form
- Imports library on auto-login on launcher startup
- Fixes keep-alive after a failed connection and reconnecting
- Adds info about retries when connection to server is lost
- Fixes #262

Technical changes:
- Stores app-wide state for connection state being a "singleton" instance
- Limits the suggested URIs on attempt to connect to server, when given a fully qualified server address


Known issues:
- #270 still exists which can happen on logging in from temporary offline mode

<details><summary>Video demostration of old issues</summary>


### **UI not opening - Visible at 5:48**

https://github.com/user-attachments/assets/058a242a-debe-4638-b388-d8de95ff797c


### **Connecting takes long**

https://github.com/user-attachments/assets/a6ba3884-427f-4d8f-a766-80684ac90002


### **Multiple import**

https://github.com/user-attachments/assets/c95afa74-7a52-4ffb-8fea-14b2e3a4721f

### Re-auth/login on startup (no issue)

https://github.com/user-attachments/assets/eb71533c-c1a1-4a48-a5ec-ba7d0f9c79f2

</details> 


<details>
  <summary><strong>Video Demonstration of this PR</strong></summary>

### Offline startup
https://github.com/user-attachments/assets/f17b82d3-3fc0-4813-ab08-68df1cc7efa2

### Offline mode

https://github.com/user-attachments/assets/b59b1c4f-bdf7-4e2f-a856-47bc822aa4a9

### Offline UI

https://github.com/user-attachments/assets/ed36c44b-55b3-400a-b725-4fbe171d1ede

### Re-auth/login on startup

https://github.com/user-attachments/assets/7428d3a5-1543-4f59-98ef-cddc8c6e9a14



</details>
