### PR TITLE
[Launcher] Fix connecting to hostname:port Uri

### DIFF
--- a/LANCommander.SDK/Extensions/UriExtensions.cs
+++ b/LANCommander.SDK/Extensions/UriExtensions.cs
@@ -7,6 +7,60 @@ namespace LANCommander.SDK.Extensions;
 
 public static class UriExtensions
 {
+    /// <summary>
+    /// Creates an absolute URI from a string that may or may not include a scheme.
+    /// If the string does not contain a scheme (e.g., "http://" or "https://"), it defaults to "http://".
+    /// Throws an exception if the input is null, empty, or not a valid URI.
+    /// </summary>
+    /// <param name="input">The input URI string.</param>
+    /// <returns>A valid absolute Uri.</returns>
+    /// <exception cref="ArgumentException">Thrown if the input is invalid.</exception>
+    public static Uri CreateUri(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            throw new ArgumentException("The input URI string cannot be null or empty.", nameof(input));
+        }
+
+        // Prepend default scheme if missing.
+        if (!input.Contains("://"))
+        {
+            input = "http://" + input;
+        }
+
+        if (!Uri.TryCreate(input, UriKind.Absolute, out Uri result))
+        {
+            throw new ArgumentException($"The provided string '{input}' is not a valid absolute URI.", nameof(input));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Tries to create an absolute URI from the provided string.
+    /// If no scheme is present, it defaults to "http://".
+    /// </summary>
+    /// <param name="input">The input URI string.</param>
+    /// <param name="result">The created URI if successful; otherwise, null.</param>
+    /// <returns>True if a valid URI is created; otherwise, false.</returns>
+    public static bool TryCreateUri(string input, out Uri result)
+    {
+        result = null;
+
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return false;
+        }
+
+        // Prepend default scheme if missing.
+        if (!input.Contains("://"))
+        {
+            input = "http://" + input;
+        }
+
+        return Uri.TryCreate(input, UriKind.Absolute, out result);
+    }
+
     public static IEnumerable<Uri> SuggestValidUris(this string url)
     {
         List<Uri> uris = new();
@@ -22,10 +76,8 @@ public static class UriExtensions
         // Generate URIs based on provided URL 
         try
         {
-            if (Uri.IsWellFormedUriString(url, UriKind.Absolute))
+            if (Uri.IsWellFormedUriString(url, UriKind.Absolute) && TryCreateUri(url, out var uri))
             {
-                var uri = new Uri(url);
-            
                 uris.Add(uri);
             
                 if (uri.Scheme != Uri.UriSchemeHttp)


### PR DESCRIPTION
Fix connecting to hostname:port Uri

Changes: 
- Corrects parsing the hostname:port given url/uri
- Adds `UriExtensions.CreateUri` and `UriExtensions.TryCreateUri`
- Fixes #304

Technical reason:
The Url given by `localhost:1337` for instance is parsed as relative URL instead of an absolute URI. In this case 1337 is treated as path without any port. In my tests the parsed URL resulted into `http://1337` respectively `0.0.5.57` which isn't anything in my local network nor configured in any NICs therefore establishing a connection is failed.