### PR TITLE
Bypass password policy on first-time-setup for administrator creation

### DIFF
--- a/LANCommander.Server/UI/Pages/FirstTimeSetup/Administrator.razor
+++ b/LANCommander.Server/UI/Pages/FirstTimeSetup/Administrator.razor
@@ -106,8 +106,7 @@
 
                 try
                 {
-                    await UserService.AddAsync(user);
-                    await UserService.ChangePassword(user.UserName, Model.Password);
+                    await UserService.AddAsync(user, bypassPasswordPolicy: true, Model.Password);
                     await UserService.AddToRolesAsync(user.UserName, [RoleService.AdministratorRoleName]);
 
                     Logger?.LogInformation("Administrator created a new account with password.");


### PR DESCRIPTION
Bypasses password policy on creation of an initial administrator user account on first-time setup process

Changes: 
- Changes method `UserService.AddAsync(..)` by adding `bypassPasswordPolicy` to bypass password policy
- Changes method `UserService.ChangePassword(..)` by adding `bypassPolicy` to bypass password policy 
- Should handle #258, but needs verifying for second issue
