### PR TITLE
Error messaging for login/register via Launcher

### DIFF
--- a/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
@@ -1,3 +1,4 @@
+@using LANCommander.SDK.Exceptions
 @using LANCommander.SDK.Models
 @inject AuthenticationService AuthenticationService
 @inject SDK.Client Client
@@ -12,6 +13,12 @@
     </TitleTemplate>
 </PageHeader>
 <Form Model="@Model" Loading="@Loading" Layout="FormLayout.Vertical" OnFinish="OnFinish">
+
+    @foreach (var item in Errors)
+    {
+        <Alert Message="@item" Type="AlertType.Error" ShowIcon="true" Style="margin-bottom: 8px;" />
+    }
+
     <FormItem Label="Server Address">
         <Input Value="ServerAddress" Disabled />
     </FormItem>
@@ -64,20 +71,22 @@
     [Parameter] public string ServerAddress { get; set; }
     [Parameter] public EventCallback OnBack { get; set; }
     [Parameter] public EventCallback OnRegister { get; set; }
+    [Parameter] public IEnumerable<string> Errors { get; set; } = [];
 
     List<AuthenticationProvider> AuthenticationProviders = new();
 
     AuthRequest Model = new();
     bool Loading = false;
     AuthenticationProviderDialog AuthenticationProviderDialog;
-    
+
     Models.Settings Settings = SettingService.GetSettings();
 
     protected override async Task OnParametersSetAsync()
     {
         AuthenticationProviders = new();
-        
+
         await Client.ChangeServerAddressAsync(ServerAddress);
+        ClearErrors();
 
         try
         {
@@ -90,7 +99,13 @@
         {
             Logger.LogError(ex, "Could not get authentication providers");
         }
-        
+
+        StateHasChanged();
+    }
+
+    protected void ClearErrors()
+    {
+        Errors = [];
         StateHasChanged();
     }
 
@@ -100,6 +115,8 @@
 
         try
         {
+            ClearErrors();
+
             await AuthenticationService.Login(Client.GetServerAddress(), Model.UserName, Model.Password);
 
             await ImportManagerService.RequestImport();
@@ -108,10 +125,18 @@
             
             MessageService.Success("Welcome back!");
         }
+        catch (AuthFailedException ex)
+        {
+            Errors = ex.ErrorData.Details?.Select(x => x.Message) ?? [];
+            MessageService.Error(ex.Message, 5);
+        }
         catch (Exception ex)
         {
             MessageService.Error(ex.Message, 5);
             Logger.LogError(ex, ex.Message);
+        }
+        finally
+        {
             Loading = false;
         }
     }

--- a/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
@@ -1,3 +1,4 @@
+@using LANCommander.SDK.Exceptions
 @using LANCommander.SDK.Models
 @inject AuthenticationService AuthenticationService
 @inject SDK.Client Client
@@ -12,6 +13,12 @@
     </TitleTemplate>
 </PageHeader>
 <Form Model="@Model" Loading="@Loading" Layout="FormLayout.Vertical" OnFinish="OnFinish">
+
+    @foreach (var item in Errors)
+    {
+        <Alert Message="@item" Type="AlertType.Error" ShowIcon="true" Style="margin-bottom: 8px;" />
+    }
+
     <FormItem Label="Server Address">
         <Input Value="ServerAddress" Disabled />
     </FormItem>
@@ -34,16 +41,22 @@
 @code {
     [Parameter] public string ServerAddress { get; set; }
     [Parameter] public EventCallback OnBack { get; set; }
+    [Parameter] public IEnumerable<string> Errors { get; set; } = [];
 
     RegistrationRequest Model = new();
     bool Loading = false;
-    
+
     Models.Settings Settings = SettingService.GetSettings();
 
     protected override async Task OnParametersSetAsync()
     {
         await Client.ChangeServerAddressAsync(ServerAddress);
-        
+        ClearErrors();
+    }
+
+    protected void ClearErrors()
+    {
+        Errors = [];
         StateHasChanged();
     }
 
@@ -53,16 +66,26 @@
 
         try
         {
+            ClearErrors();
+
             await AuthenticationService.Register(Client.GetServerAddress(), Model.UserName, Model.Password, Model.PasswordConfirmation);
 
             await ImportManagerService.RequestImport();
 
             NavigationManager.NavigateTo("/");
         }
+        catch (RegisterFailedException ex)
+        {
+            Errors = ex.ErrorData.Details?.Select(x => x.Message) ?? [];
+            MessageService.Error(ex.Message, 5);
+        }
         catch (Exception ex)
         {
             MessageService.Error(ex.Message, 5);
             Logger.LogError(ex, ex.Message);
+        }
+        finally
+        {
             Loading = false;
         }
     }

--- a/LANCommander.SDK/Client.cs
+++ b/LANCommander.SDK/Client.cs
@@ -1,7 +1,11 @@
 ﻿using LANCommander.SDK.Models;
 using LANCommander.SDK.PowerShell.Cmdlets;
 using LANCommander.SDK.Services;
+using LANCommander.SDK.Extensions;
+using LANCommander.SDK.Exceptions;
+
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using RestSharp;
 using RestSharp.Interceptors;
 using Semver;
@@ -16,7 +20,6 @@ using System.Net.NetworkInformation;
 using System.Reflection;
 using System.ServiceModel.Channels;
 using System.Threading.Tasks;
-using LANCommander.SDK.Extensions;
 
 namespace LANCommander.SDK
 {
@@ -635,11 +638,12 @@ namespace LANCommander.SDK
 
                 var response = await ApiClient.ExecuteAsync<AuthToken>(request);
 
-                if (response.ErrorException != null)
+                ErrorResponse errorResponse = null;
+                if (response.ResponseStatus == ResponseStatus.Error || response.ErrorException != null)
                 {
-                    Logger?.LogError(response.ErrorException, "Authentication failed for user {UserName}", username);
-
-                    throw new Exception(response.Content);
+                    string message = response.ErrorMessage ?? response?.ErrorException.Message;
+                    Logger?.LogError(response.ErrorException, "Authentication failed for user {UserName}: {Message}", username, message);
+                    errorResponse = ParseErrorResponse(response);
                 }
 
                 switch (response.StatusCode)
@@ -663,19 +667,19 @@ namespace LANCommander.SDK
                     case HttpStatusCode.Unauthorized:
                         Connected = false;
                         Logger?.LogError("Authentication failed for user {UserName}: invalid username or password", username);
-                        throw new WebException("Invalid username or password");
+                        throw new AuthFailedException(AuthFailedException.AuthenticationErrorCode.InvalidCredentials, "Invalid username or password", errorData: errorResponse, innerException: response.ErrorException);
 
                     default:
                         Connected = false;
                         Logger?.LogError("Authentication failed for user {UserName}: could not communicate with the server", username);
-                        throw new WebException("Could not communicate with the server");
+                        throw new WebException("Could not communicate with the server", innerException: response.ErrorException);
                 }
             }
             catch (Exception ex)
             {
                 OnError?.Invoke(this, ex);
                 
-                return default;
+                throw;
             }
         }
 
@@ -694,51 +698,56 @@ namespace LANCommander.SDK
 
         public async Task<AuthToken> RegisterAsync(string username, string password, string passwordConfirmation)
         {
-            var response = await ApiClient.ExecuteAsync<AuthResponse>(new RestRequest("/api/Auth/Register", Method.Post).AddJsonBody(new AuthRequest()
+            try
             {
-                UserName = username,
-                Password = password
-            }));
-
-            if (response.ErrorException != null)
-            {
-                Logger?.LogError(response.ErrorException, "Registration failed for user {UserName}", username);
-
-                if (!String.IsNullOrWhiteSpace(response?.Data?.Message))
+                var request = new RestRequest("/api/Auth/Register", Method.Post);
+                request.AddJsonBody(new AuthRequest()
                 {
-                    Logger?.LogError(response.Data.Message);
-                    
-                    OnError?.Invoke(this, response.ErrorException);
+                    UserName = username,
+                    Password = password
+                });
 
-                    throw new Exception(response.Data.Message);
+                var response = await ApiClient.ExecuteAsync<AuthResponse>(request);
+
+                ErrorResponse errorResponse = null;
+                if (response.ResponseStatus == ResponseStatus.Error || response.ErrorException != null)
+                {
+                    string message = response.ErrorMessage ?? response?.ErrorException.Message;
+                    Logger?.LogError(response.ErrorException, "Registration failed for user {UserName}: {Message}", username, message);
+                    errorResponse = ParseErrorResponse(response);
                 }
-                else
-                    throw response.ErrorException;
+
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                        Token = new AuthToken
+                        {
+                            AccessToken = response.Data.AccessToken,
+                            RefreshToken = response.Data.RefreshToken,
+                            Expiration = response.Data.Expiration
+                        };
+
+                        Connected = true;
+
+                        return Token;
+
+                    case HttpStatusCode.BadRequest:
+                    case HttpStatusCode.Forbidden:
+                    case HttpStatusCode.Unauthorized:
+                        Connected = false;
+                        throw new RegisterFailedException(response.Data.Message, errorData: errorResponse, innerException: response.ErrorException);
+
+                    default:
+                        Connected = false;
+                        Logger?.LogError("Registering failed for user {UserName}: could not communicate with the server", username);
+                        throw new WebException("Could not communicate with the server", innerException: response.ErrorException);
+                }
             }
-
-            switch (response.StatusCode)
+            catch (Exception ex)
             {
-                case HttpStatusCode.OK:
-                    Token = new AuthToken
-                    {
-                        AccessToken = response.Data.AccessToken,
-                        RefreshToken = response.Data.RefreshToken,
-                        Expiration = response.Data.Expiration
-                    };
+                OnError?.Invoke(this, ex);
 
-                    Connected = true;
-
-                    return Token;
-
-                case HttpStatusCode.BadRequest:
-                case HttpStatusCode.Forbidden:
-                case HttpStatusCode.Unauthorized:
-                    Connected = false;
-                    throw new WebException(response.Data.Message);
-
-                default:
-                    Connected = false;
-                    throw new WebException("Could not communicate with the server");
+                throw;
             }
         }
 
@@ -937,6 +946,32 @@ namespace LANCommander.SDK
                 host = entry.AddressList.First().ToString();
 
             return host;
+        }
+
+        internal ErrorResponse ParseErrorResponse(RestResponse response, bool defaultToGenericResponse = false)
+        {
+            ErrorResponse errorResponse = null;
+
+            // Try to deserialize the error response.
+            try
+            {
+                errorResponse = JsonConvert.DeserializeObject<ErrorResponse>(response.Content);
+                return errorResponse;
+            }
+            catch (Exception deserializationEx)
+            {
+                // Log error and create a fallback message if deserialization fails.
+                if (defaultToGenericResponse)
+                {
+                    Logger?.LogError(deserializationEx, "Error deserializing error response for route {Route}", response.Request);
+                    errorResponse = new ErrorResponse
+                    {
+                        Message = "Could not process the server response."
+                    };
+                }
+            }
+
+            return errorResponse;
         }
     }
 }

--- a/LANCommander.SDK/Exceptions/AuthFailedException.cs
+++ b/LANCommander.SDK/Exceptions/AuthFailedException.cs
@@ -1,0 +1,46 @@
+﻿using LANCommander.SDK.Models;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace LANCommander.SDK.Exceptions
+{
+    public class AuthFailedException : Exception
+    {
+        public enum AuthenticationErrorCode
+        {
+            InvalidCredentials,
+            PasswordExpired,
+            TokenExpired,
+        }
+
+        /// <summary>
+        /// Categorizes the failure so callers can switch on it.
+        /// </summary>
+        public AuthenticationErrorCode ErrorCode { get; }
+
+        public ErrorResponse ErrorData { get; }
+
+        public AuthFailedException(string message) : base(message) { }
+
+        public AuthFailedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public AuthFailedException(AuthenticationErrorCode errorCode, ErrorResponse errorData = null)
+            : base($"Authentication failed: {errorCode}")
+        {
+            ErrorCode = errorCode;
+            ErrorData = errorData;
+        }
+
+        public AuthFailedException(AuthenticationErrorCode errorCode, string message, ErrorResponse errorData = null, Exception innerException = null)
+            : base(message, innerException)
+        {
+            ErrorCode = errorCode;
+            ErrorData = errorData;
+        }
+    }
+}

--- a/LANCommander.SDK/Exceptions/RegisterFailedException.cs
+++ b/LANCommander.SDK/Exceptions/RegisterFailedException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using LANCommander.SDK.Models;
+
+namespace LANCommander.SDK.Exceptions
+{
+    public class RegisterFailedException : Exception
+    {
+        public ErrorResponse ErrorData  { get; }
+
+        public RegisterFailedException(string message) : base(message) { }
+
+        public RegisterFailedException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public RegisterFailedException(ErrorResponse errorData)
+            : base($"Registration failed: {errorData}")
+        {
+            ErrorData = errorData;
+        }
+
+        public RegisterFailedException(string message, ErrorResponse errorData = null, Exception innerException = null)
+            : base(message, innerException)
+        {
+            ErrorData = errorData;
+        }
+    }
+}

--- a/LANCommander.SDK/Models/ErrorResponse.cs
+++ b/LANCommander.SDK/Models/ErrorResponse.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace LANCommander.SDK.Models;
+
+public class ErrorResponse
+{
+    public struct ErrorInfo
+    {
+        public string Key { get; set; }
+        public string Message { get; set; }
+
+        internal static string GetMessage(ErrorInfo info) => info.Message;
+    }
+
+    /// <summary>
+    /// Short error title or code.
+    /// </summary>
+    public string Error { get; set; }
+
+    /// <summary>
+    /// Detailed, user-friendly error message.
+    /// </summary>
+    public string Message { get; set; }
+
+    /// <summary>
+    /// Optional list of detailed error messages (e.g., from validation failures).
+    /// </summary>
+    public IEnumerable<ErrorInfo> Details { get; set; }
+
+    /// <summary>
+    /// Optional list of detailed error messages (e.g., from validation failures).
+    /// </summary>
+    public IEnumerable<string> DetailsMessages => Details?.Select(ErrorInfo.GetMessage);
+}

--- a/LANCommander.Server.Services/AuthenticationService.cs
+++ b/LANCommander.Server.Services/AuthenticationService.cs
@@ -158,6 +158,12 @@ namespace LANCommander.Server.Services
             user = new Data.Models.User();
             user.UserName = userName;
 
+            var registerResult = await userService.CheckRegister(user, password);
+            if (!registerResult.Succeeded)
+            {
+                throw new UserRegistrationException(registerResult, "Could not register user");
+            }
+
             user = await userService.AddAsync(user);
 
             if (user != null)

--- a/LANCommander.Server.Services/Exceptions/IdentityException.cs
+++ b/LANCommander.Server.Services/Exceptions/IdentityException.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace LANCommander.Server.Services.Exceptions;
+
+public abstract class IdentityException : Exception
+{
+    public IdentityResult IdentityResult { get; set; }
+
+    public IdentityException(string message) : this(message, innerException: null)
+    {
+    }
+
+    public IdentityException(string message, Exception? innerException) : base(message, innerException)
+    {
+        IdentityResult = IdentityResult.Failed(new IdentityError()
+        {
+            Code = "",
+            Description = message,
+        });
+    }
+
+    public IdentityException(IdentityResult identityResult, string message) : this(identityResult, message, innerException: null)
+    { 
+    }
+
+    public IdentityException(IdentityResult identityResult, string message, Exception? innerException) : base(message)
+    {
+        IdentityResult = identityResult;
+    }
+}

--- a/LANCommander.Server.Services/Exceptions/UserAuthenticationException.cs
+++ b/LANCommander.Server.Services/Exceptions/UserAuthenticationException.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace LANCommander.Server.Services.Exceptions;
+
+public class UserAuthenticationException : IdentityException
+{
+    public UserAuthenticationException(string message) : base(message) { }
+    public UserAuthenticationException(IdentityResult identityResult, string message) : base(identityResult, message) { }
+
+    public UserAuthenticationException(string message, Exception? innerException) : base(message, innerException) { }
+    public UserAuthenticationException(IdentityResult identityResult, string message, Exception? innerException) : base(identityResult, message, innerException) { }
+
+}

--- a/LANCommander.Server.Services/Exceptions/UserRegistrationException.cs
+++ b/LANCommander.Server.Services/Exceptions/UserRegistrationException.cs
@@ -2,16 +2,11 @@ using Microsoft.AspNetCore.Identity;
 
 namespace LANCommander.Server.Services.Exceptions;
 
-public class UserRegistrationException : Exception
+public class UserRegistrationException : IdentityException
 {
-    public IdentityResult IdentityResult { get; set; }
+    public UserRegistrationException(string message) : base(message) { }
+    public UserRegistrationException(IdentityResult identityResult, string message) : base(identityResult, message) { }
 
-    public UserRegistrationException(string message) : base(message)
-    {
-    }
-
-    public UserRegistrationException(IdentityResult identityResult, string message) : base(message)
-    {
-        IdentityResult = identityResult;
-    }
+    public UserRegistrationException(string message, Exception? innerException) : base(message, innerException) { }
+    public UserRegistrationException(IdentityResult identityResult, string message, Exception? innerException) : base(identityResult, message, innerException) { }
 }

--- a/LANCommander.Server.Services/UserService.cs
+++ b/LANCommander.Server.Services/UserService.cs
@@ -36,6 +36,19 @@ namespace LANCommander.Server.Services
             Cache = cache;
         }
 
+        public void Reconfigure(Settings settings)
+        {
+            var options = IdentityContext.UserManager.Options;
+            if (options == null || settings == null) 
+                return;
+
+            options.Password.RequireNonAlphanumeric = settings.Authentication.PasswordRequireNonAlphanumeric;
+            options.Password.RequireLowercase = settings.Authentication.PasswordRequireLowercase;
+            options.Password.RequireUppercase = settings.Authentication.PasswordRequireUppercase;
+            options.Password.RequireDigit = settings.Authentication.PasswordRequireDigit;
+            options.Password.RequiredLength = settings.Authentication.PasswordRequiredLength;
+        }
+
         public async Task<User> GetAsync(string userName)
         {
             return await FirstOrDefaultAsync(u => u.UserName.ToUpper() == userName.ToUpper());

--- a/LANCommander.Server/Controllers/Api/AuthController.cs
+++ b/LANCommander.Server/Controllers/Api/AuthController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authentication;
 using ZiggyCreatures.Caching.Fusion;
 using AuthenticationService = LANCommander.Server.Services.AuthenticationService;
 using User = LANCommander.Server.Data.Models.User;
+using LANCommander.Server.Services.Exceptions;
 
 namespace LANCommander.Server.Controllers.Api
 {
@@ -94,6 +95,24 @@ namespace LANCommander.Server.Controllers.Api
 
                 return Ok(token);
             }
+            catch (UserAuthenticationException ex)
+            {
+                // Optionally, map IdentityResult errors into a string list
+                List<ErrorResponse.ErrorInfo> errorDetails = ex.IdentityResult?.Errors.Select(FromIdentityResult).ToList() ?? [];
+                if (errorDetails.Count == 0)
+                {
+                    errorDetails.Add(new ErrorResponse.ErrorInfo { Message = ex.Message });
+                }
+
+                var errorResponse = new ErrorResponse
+                {
+                    Error = "AuthenticationFailed",
+                    Message = "User authentication failed.",
+                    Details = errorDetails,
+                };
+
+                return Unauthorized(errorResponse);
+            }
             catch (Exception ex)
             {
                 Logger?.LogError(ex, "An error occurred while trying to log in {UserName}", model.UserName);
@@ -145,8 +164,27 @@ namespace LANCommander.Server.Controllers.Api
 
                 return Ok(token);
             }
+            catch (UserRegistrationException ex)
+            {
+                // Optionally, map IdentityResult errors into a string list
+                List<ErrorResponse.ErrorInfo> errorDetails = ex.IdentityResult?.Errors.Select(FromIdentityResult).ToList() ?? [];
+                if (errorDetails.Count == 0)
+                {
+                    errorDetails.Add(new ErrorResponse.ErrorInfo { Message = ex.Message });
+                }
+
+                var errorResponse = new ErrorResponse
+                {
+                    Error = "UserRegistrationFailed",
+                    Message = "User registration failed.",
+                    Details = errorDetails,
+                };
+
+                return Unauthorized(errorResponse);
+            }
             catch (Exception ex)
             {
+                Logger.LogError(ex, ex.Message);
                 return Unauthorized(ex.Message);
             }
         }
@@ -155,6 +193,15 @@ namespace LANCommander.Server.Controllers.Api
         public IActionResult GetAuthenticationProviders()
         {
             return Ok(Mapper.Map<IEnumerable<AuthenticationProvider>>(Settings.Authentication.AuthenticationProviders));
+        }
+
+        static ErrorResponse.ErrorInfo FromIdentityResult(IdentityError error)
+        {
+            return new ErrorResponse.ErrorInfo
+            {
+                Key = error.Code,
+                Message = error.Description,
+            };
         }
     }
 }

--- a/LANCommander.Server/UI/Pages/Settings/Authentication/Index.razor
+++ b/LANCommander.Server/UI/Pages/Settings/Authentication/Index.razor
@@ -3,6 +3,7 @@
 @using LANCommander.Server.UI.Pages.Settings.Authentication.Components
 @inject IMessageService MessageService
 @inject ILogger<Index> Logger
+@inject IServiceProvider ServiceProvider
 @attribute [Authorize(Roles = RoleService.AdministratorRoleName)]
 
 <PageHeader Title="Authentication">
@@ -59,6 +60,7 @@
 </PageContent>
 
 @code {
+
     Settings Settings = SettingService.GetSettings();
 
     string FormatTokenLifetime(int value)
@@ -75,8 +77,9 @@
                 if (String.IsNullOrWhiteSpace(authenticationProvider.Slug))
                     authenticationProvider.Slug = authenticationProvider.Name.ToPascalCase();
             }
-            
-            SettingService.SaveSettings(Settings);
+
+            SettingService.SaveSettings(Settings, ServiceProvider);
+
             MessageService.Success("Settings saved!");
         }
         catch (Exception ex)


### PR DESCRIPTION
### Error messaging for login/register, prevent user account, no deadlock for wrong password

Issues before:
- Users were created with registering form launchers with a invalid password
- Login with invalid password will deadlock the launcher
- No info about the bad password on registering from the launcher
- Changes to password policy won't apply without server restart

This PR includes the following:
- Login will properly abort and unlock UI on invalid password
- Error message about login or register will be shown as messages
- Changes to authentication will now be applied directly to the auth logic
- Fixes #309
- Fixes #310
- Should also finally fully fix and close #258

Technical changes:
- Added `IdentityException` (Base) and `UserAuthenticationException` for handling error messaging from service to SDK/Client
- Added `AuthFailedException` and `RegisterFailedException` providing error message via `ErrorResponse` to frontend/SDK

Known issues:
- Changes (2099c70) done by #306 are not included


<details><summary>Video demostration of issues</summary>

### **Login with wrong password** - Nothing happens after 0:15

https://github.com/user-attachments/assets/84eab85a-3bb5-4511-b47a-96981006dbf9

### **Register**

https://github.com/user-attachments/assets/8ade510d-d906-4ba7-ac52-46a1696d7fd8


</details> 


<details>
  <summary><strong>Video Demonstration of this PR</strong></summary>

### Fix Login, Register

https://github.com/user-attachments/assets/9a6af609-adb4-4840-8e34-95cf99004e8e

</details>
