### PR TITLE
Fix editing collection and other metadata pages

### DIFF
--- a/LANCommander.Server/UI/Pages/Metadata/Collections/Edit.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Collections/Edit.razor
@@ -1,5 +1,6 @@
 ﻿@page "/Metadata/Collections/{id:guid}"
 @page "/Metadata/Collections/Add"
+@using Microsoft.EntityFrameworkCore
 @attribute [Authorize(Roles = RoleService.AdministratorRoleName)]
 @inject CollectionService CollectionService
 @inject IMessageService MessageService
@@ -80,7 +81,17 @@
             Collection = new Collection();
         else
             Collection = await CollectionService
-                .Include(c => c.Games)
+                .Query(q =>
+                {
+                    return q
+                        .Include(c => c.Games).ThenInclude(g => g.Media)
+                        .Include(c => c.Games).ThenInclude(g => g.Developers)
+                        .Include(c => c.Games).ThenInclude(g => g.Publishers)
+                        .Include(c => c.Games).ThenInclude(g => g.Genres)
+                        .Include(c => c.Games).ThenInclude(g => g.MultiplayerModes)
+                        ;
+                })
+                .AsSplitQuery()
                 .GetAsync(Id);
     }
 

--- a/LANCommander.Server/UI/Pages/Metadata/Collections/Edit.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Collections/Edit.razor
@@ -19,42 +19,42 @@
     <Column TData="string" Title="Icon">
         <Image Src="@GetIcon(context)" Height="32" Width="32" Preview="false"></Image>
     </Column>
-    
+
     <PropertyColumn Property="g => g.Title" Sortable Filterable DefaultSortOrder="SortDirection.Ascending" />
-    
+
     <PropertyColumn Property="g => g.ReleasedOn" Format="MM/dd/yyyy" Sortable Filterable />
-    
+
     <PropertyColumn Property="g => g.Singleplayer" Sortable Filterable>
         <Checkbox Disabled="true" Checked="context.Singleplayer" />
     </PropertyColumn>
-    
+
     <Column TData="bool" Title="Multiplayer">
         <Checkbox Disabled="true" Checked="context.MultiplayerModes?.Count > 0" />
     </Column>
 
     <Column TData="string[]" Title="Developers">
-        @foreach (var dev in context.Developers)
+        @foreach (var dev in context.Developers ?? [])
         {
             <Tag>@dev.Name</Tag>
         }
     </Column>
 
     <Column TData="string[]" Title="Publishers">
-        @foreach (var pub in context.Publishers)
+        @foreach (var pub in context.Publishers ?? [])
         {
             <Tag>@pub.Name</Tag>
         }
     </Column>
 
     <Column TData="string[]" Title="Genres">
-        @foreach (var genre in context.Genres)
+        @foreach (var genre in context.Genres ?? [])
         {
             <Tag>@genre.Name</Tag>
         }
     </Column>
 
     <Column TData="SDK.Enums.MultiplayerType[]" Title="Multiplayer Modes">
-        @foreach (var mode in context.MultiplayerModes.Select(mm => mm.Type).Distinct())
+        @foreach (var mode in context.MultiplayerModes?.Select(mm => mm.Type).Distinct() ?? [])
         {
             <Tag>@mode.GetDisplayName()</Tag>
         }

--- a/LANCommander.Server/UI/Pages/Metadata/Companies/Index.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Companies/Index.razor
@@ -29,6 +29,10 @@
         <BoundDataColumn Property="c => c.DevelopedGames.Count" Sortable Title="Developed Games" Include="DevelopedGames" />
         <BoundDataColumn Property="c => c.PublishedGames.Count" Sortable Title="Published Games" Include="PublishedGames" />
         <DataActions TData="string">
+            <Button OnClick="() => OpenEdit(context)" Type="@ButtonType.Primary">Edit</Button>
+            @* TODO: Add seperate Edit page and navigate to it *@
+            @* <a href="@($"/Metadata/Engines/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a> *@
+
             <Popconfirm OnConfirm="() => Delete(context)" Title="Are you sure you want to delete this company?">
                 <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Close" Danger />
             </Popconfirm>
@@ -84,10 +88,11 @@
         await CloseEdit();
     }
 
-    async Task OpenEdit(Company company)
+    async Task OpenEdit(Company? company)
     {
-        if (company != null)
-            CompanyContext = company;
+        // query new instance, or create a new Edit context instance
+        CompanyContext = company != null ? await CompanyService.GetAsync(company.Id) : default!;
+        CompanyContext ??= new();
 
         EditCompanyVisible = true;
 

--- a/LANCommander.Server/UI/Pages/Metadata/Engines/Index.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Engines/Index.razor
@@ -27,7 +27,10 @@
         </BoundDataColumn>
         <BoundDataColumn Property="e => e.UpdatedBy != null ? e.UpdatedBy.UserName : String.Empty" Title="Updated By" Sortable Include="UpdatedBy" />
         <DataActions TData="string">
-            <a href="@($"/Metadata/Engines/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a>
+            <Button OnClick="() => OpenEdit(context)" Type="@ButtonType.Primary">Edit</Button>
+            @* TODO: Add seperate Edit page and navigate to it *@
+            @* <a href="@($"/Metadata/Engines/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a> *@
+
             <Popconfirm OnConfirm="() => Delete(context)" Title="Are you sure you want to delete this engine?">
                 <Button Icon="@IconType.Outline.Close" Type="@ButtonType.Text" Danger />
             </Popconfirm>
@@ -47,8 +50,6 @@
 </Modal>
 
  @code {
-    IEnumerable<Engine> Engines { get; set; } = new List<Engine>();
-
     bool Loading = true;
 
     bool EditEngineVisible = false;
@@ -93,11 +94,12 @@
         await CloseEdit();
     }
 
-    async Task OpenEdit(Engine engine)
+    async Task OpenEdit(Engine? engine)
     {
-        if (engine != null)
-            EngineContext = engine;
-
+        // query new instance, or create a new Edit context instance
+        EngineContext = engine != null ? await EngineService.GetAsync(engine.Id) : default!;
+        EngineContext ??= new();
+        
         EditEngineVisible = true;
 
         await InvokeAsync(StateHasChanged);

--- a/LANCommander.Server/UI/Pages/Metadata/Genres/Index.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Genres/Index.razor
@@ -27,7 +27,10 @@
         </BoundDataColumn>
         <BoundDataColumn Property="g => g.UpdatedBy != null ? g.UpdatedBy.UserName : String.Empty" Title="Updated By" Sortable Include="UpdatedBy" />
         <DataActions TData="string">
-            <a href="@($"/Metadata/Genres/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a>
+            <Button OnClick="() => OpenEdit(context)" Type="@ButtonType.Primary">Edit</Button>
+            @* TODO: Add seperate Edit page and navigate to it *@
+            @* <a href="@($"/Metadata/Genres/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a> *@
+
             <Popconfirm OnConfirm="() => Delete(context)" Title="Are you sure you want to delete this genre?">
                 <Button Icon="@IconType.Outline.Close" Type="@ButtonType.Text" Danger />
             </Popconfirm>
@@ -91,10 +94,11 @@
         await CloseEdit();
     }
 
-    async Task OpenEdit(Genre genre)
+    async Task OpenEdit(Genre? genre)
     {
-        if (genre != null)
-            GenreContext = genre;
+        // query new instance, or create a new Edit context instance
+        GenreContext = genre != null ? await GenreService.GetAsync(genre.Id) : default!;
+        GenreContext ??= new();
 
         EditGenreVisible = true;
 

--- a/LANCommander.Server/UI/Pages/Metadata/Platforms/Index.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Platforms/Index.razor
@@ -27,7 +27,10 @@
         </BoundDataColumn>
         <BoundDataColumn Property="p => p.UpdatedBy != null ? p.UpdatedBy.UserName : String.Empty" Title="Updated By" Sortable Include="UpdatedBy" />
         <DataActions TData="string">
-            <a href="@($"/Metadata/Platforms/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a>
+            <Button OnClick="() => OpenEdit(context)" Type="@ButtonType.Primary">Edit</Button>
+            @* TODO: Add seperate Edit page and navigate to it *@
+            @* <a href="@($"/Metadata/Platforms/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a> *@
+
             <Popconfirm OnConfirm="() => Delete(context)" Title="Are you sure you want to delete this platform?">
                 <Button Icon="@IconType.Outline.Close" Type="@ButtonType.Text" Danger />
             </Popconfirm>
@@ -47,8 +50,6 @@
 </Modal>
 
  @code {
-    IEnumerable<Platform> Platforms { get; set; } = new List<Platform>();
-
     bool Loading = true;
 
     bool EditPlatformVisible = false;
@@ -93,10 +94,11 @@
         await CloseEdit();
     }
 
-    async Task OpenEdit(Platform platform)
+    async Task OpenEdit(Platform? platform)
     {
-        if (platform != null)
-            PlatformContext = platform;
+        // query new instance, or create a new Edit context instance
+        PlatformContext = platform != null ? await PlatformService.GetAsync(platform.Id) : default!;
+        PlatformContext ??= new();
 
         EditPlatformVisible = true;
 

--- a/LANCommander.Server/UI/Pages/Metadata/Tags/Index.razor
+++ b/LANCommander.Server/UI/Pages/Metadata/Tags/Index.razor
@@ -27,7 +27,10 @@
         </BoundDataColumn>
         <BoundDataColumn Property="t => t.UpdatedBy != null ? t.UpdatedBy.UserName : String.Empty" Title="Updated By" Sortable Include="UpdatedBy" />
         <DataActions TData="string">
-            <a href="@($"/Metadata/Tags/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a>
+            <Button OnClick="() => OpenEdit(context)" Type="@ButtonType.Primary">Edit</Button>
+            @* TODO: Add seperate Edit page and navigate to it *@
+            @* <a href="@($"/Metadata/Tags/{context.Id}")" class="ant-btn ant-btn-primary">Edit</a> *@
+
             <Popconfirm OnConfirm="() => Delete(context)" Title="Are you sure you want to delete this tag?">
                 <Button Icon="@IconType.Outline.Close" Type="@ButtonType.Text" Danger />
             </Popconfirm>
@@ -91,10 +94,11 @@
         await CloseEdit();
     }
 
-    async Task OpenEdit(Data.Models.Tag tag)
+    async Task OpenEdit(Data.Models.Tag? tag)
     {
-        if (tag != null)
-            TagContext = tag;
+        // query new instance, or create a new Edit context instance
+        TagContext = tag != null ? await TagService.GetAsync(tag.Id) : default!;
+        TagContext ??= new();
 
         EditTagVisible = true;
 


### PR DESCRIPTION
Fixes editing collection and entries of other metadata pages

- Fixes acessing edit page for a collection, including pre-loading data
- Fixes editing metadata entities like _Engine_, _Genre_, _Platform_, _Company_ and _Tag_
   - Showing a modal for changing name
   - Using separate instance
- Fixes #311 

<details>
  <summary>Demonstration</summary>

Bug:

https://github.com/user-attachments/assets/f951b540-79a9-485c-b8ad-c7a6a8cbbaad

**Fix**:

https://github.com/user-attachments/assets/3f0fdb4a-34af-4f26-b68c-393672425d83

</details>