### PR TITLE
Fix game end lag caused by generating game save 

### DIFF
--- a/LANCommander.SDK/Services/GameService.cs
+++ b/LANCommander.SDK/Services/GameService.cs
@@ -1068,14 +1068,17 @@ namespace LANCommander.SDK.Services
                 foreach (var manifest in manifests)
                 {
                     #region Upload Saves
-                    await RetryHelper.RetryOnExceptionAsync(10, TimeSpan.FromSeconds(1), false, async () =>
+                    if (Client.IsConnected())
                     {
-                        Logger?.LogTrace("Attempting to upload save");
+                        await RetryHelper.RetryOnExceptionAsync(10, TimeSpan.FromSeconds(1), false, async () =>
+                        {
+                            Logger?.LogTrace("Attempting to upload save");
 
-                        await Client.Saves.UploadAsync(installDirectory, manifest.Id);
+                            await Client.Saves.UploadAsync(installDirectory, manifest.Id);
 
-                        return true;
-                    });
+                            return true;
+                        });
+                    }
                     #endregion
 
                     #region Run After Stop Script

--- a/LANCommander.SDK/Services/GameService.cs
+++ b/LANCommander.SDK/Services/GameService.cs
@@ -1085,7 +1085,7 @@ namespace LANCommander.SDK.Services
                     {
                         foreach (var redistributable in manifest.Redistributables.Where(r => r.Scripts != null))
                         {
-                            await Client.Scripts.RunBeforeStartScriptAsync(installDirectory, gameId, redistributable.Id);
+                            await Client.Scripts.RunAfterStopScriptAsync(installDirectory, gameId, redistributable.Id);
                         }
                     }
                     #endregion

--- a/LANCommander.SDK/Services/SaveService.cs
+++ b/LANCommander.SDK/Services/SaveService.cs
@@ -251,21 +251,26 @@ namespace LANCommander.SDK.Services
             return await Client.UploadRequestAsync<GameSave>($"/api/Saves/Game/{manifest.Id}/Upload", stream);
         }
 
-        public async Task<GameSave> UploadAsync(string installDirectory, Guid gameId)
+        public async Task<GameSave?> UploadAsync(string installDirectory, Guid gameId)
         {
             using (var savePacker = new SavePacker(installDirectory))
             {
                 var manifest = await ManifestHelper.ReadAsync<GameManifest>(installDirectory, gameId);
 
-                if (manifest?.SavePaths.Any() ?? false)
+                if (manifest?.SavePaths?.Any() ?? false)
                     savePacker.AddPaths(manifest.SavePaths);
-                
-                await savePacker.AddManifestAsync(manifest);
-                
-                var stream = await savePacker.PackAsync();
 
-                return await UploadAsync(stream, manifest);
+                if (savePacker.HasEntries())
+                {
+                    await savePacker.AddManifestAsync(manifest);
+
+                    var stream = await savePacker.PackAsync();
+
+                    return await UploadAsync(stream, manifest);
+                }
             }
+
+            return null;
         }
 
         public async Task DeleteAsync(Guid id)

--- a/LANCommander.SDK/Utilities/SavePackager.cs
+++ b/LANCommander.SDK/Utilities/SavePackager.cs
@@ -109,6 +109,16 @@ public class SavePacker : IDisposable
         _archive.AddEntry(ManifestHelper.ManifestFilename, new MemoryStream(Encoding.UTF8.GetBytes(ManifestHelper.Serialize(manifest))));
     }
 
+    public bool HasEntries()
+    {
+        return _archive.Entries.Any();
+    }
+
+    public bool HasManifest()
+    {
+        return _archive.Entries.Any(entry => string.Equals(ManifestHelper.ManifestFilename, entry.Key, StringComparison.OrdinalIgnoreCase));
+    }
+
     public async Task<Stream> PackAsync()
     {
         _archive.SaveTo(_stream, new WriterOptions(CompressionType.None)


### PR DESCRIPTION
#### Fixes game end lag caused by generating game saves without configured save paths retrying process multiple times

- Fix uploading game save taking long time if no save path is configured
- Prevent attempting to upload game save in offline mode
- Fix calling After-stop script when game ends
- Fixes #320 

<details>
  <summary>Demonstration</summary>

Bug:

https://github.com/user-attachments/assets/51171b4a-9a33-4735-a947-3b1df07c0126

**Fix**:

https://github.com/user-attachments/assets/65f69e4a-b6d0-4b98-a6af-f646684d83bf

</details>