### PR TITLE
Corrected routes for Play Sessions tracking

### DIFF
--- a/LANCommander.SDK/Services/GameService.cs
+++ b/LANCommander.SDK/Services/GameService.cs
@@ -208,7 +208,7 @@ namespace LANCommander.SDK.Services
 
             try
             {
-                await Client.PostRequestAsync<object>($"/api/Game/{id}/Started");
+                await Client.GetRequestAsync<object>($"/api/Games/{id}/Started");
             }
             catch (Exception ex)
             {
@@ -222,7 +222,7 @@ namespace LANCommander.SDK.Services
 
             try
             { 
-                await Client.PostRequestAsync<object>($"/api/Game/{id}/Stopped");
+                await Client.GetRequestAsync<object>($"/api/Games/{id}/Stopped");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
As per discussion on Discord, the Launcher didn't report correctly game sessions to the server.

This PR fixes it:
- Hits /api/Games/{id}/Started or Stopped instead of /api/Game
- GET instead of POST, as per the API specification