### PR TITLE
Fixing scripts not saved anymore in Launcher

### DIFF
--- a/LANCommander.Server.Services/GameService.cs
+++ b/LANCommander.Server.Services/GameService.cs
@@ -139,6 +139,7 @@ namespace LANCommander.Server.Services
                     .Include(g => g.Publishers)
                     .Include(g => g.Redistributables)
                     .Include(g => g.SavePaths)
+                    .Include(g => g.Scripts)
                     .Include(g => g.Tags);
             }).GetAsync(id);
 
@@ -242,6 +243,18 @@ namespace LANCommander.Server.Services
                     IsRegex = p.IsRegex,
                     WorkingDirectory = p.WorkingDirectory,
                     Type = p.Type
+                });
+            }
+
+            if (game.Scripts != null && game.Scripts.Count > 0)
+            {
+                manifest.Scripts = game.Scripts.Select(p => new SDK.Models.Script()
+                {
+                    Id = p.Id,
+                    Type = p.Type,
+                    Name = p.Name,
+                    Description = p.Description,
+                    RequiresAdmin = p.RequiresAdmin
                 });
             }
 

--- a/LANCommander.Server/Controllers/Api/GamesController.cs
+++ b/LANCommander.Server/Controllers/Api/GamesController.cs
@@ -125,6 +125,7 @@ namespace LANCommander.Server.Controllers.Api
                     .Include(g => g.Platforms)
                     .Include(g => g.Publishers)
                     .Include(g => g.Redistributables)
+                    .Include(g => g.Scripts)
                     .Include(g => g.Tags)
                     .AsNoTracking()
                     .AsSplitQuery()


### PR DESCRIPTION
Since the latest nightly, scripts (whether Games or Redistributables) were not saved nor used anymore by the Launcher.

This was due to missing scripts in the Games API, introduced by https://github.com/Mavyre/LANCommander/commit/8f6ad14d7e4240e062d5a18e3835b3aee45e18da ; Launcher is checking the scripts field to download them in the .lancommander directory

Also, I noticed that scripts were not in the local manifest. This has been for awhile without impacting their download/execution. I however added them into it for easier tracking/debugging in the future. Script `Content` field in manifest isn't included to avoid cluttered manifest.json, and double storing the script content.