### PR TITLE
Added redistributables to Games API and Games manifest

### DIFF
--- a/LANCommander.Server.Services/GameService.cs
+++ b/LANCommander.Server.Services/GameService.cs
@@ -258,6 +258,17 @@ namespace LANCommander.Server.Services
                 });
             }
 
+            if (game.Redistributables != null && game.Redistributables.Count > 0)
+            {
+                manifest.Redistributables = game.Redistributables.Select(p => new SDK.Models.Redistributable()
+                {
+                    Id = p.Id,
+                    Name = p.Name,
+                    Description = p.Description,
+                    Notes = p.Notes
+                });
+            }
+
             if (game.DependentGames != null && game.DependentGames.Count > 0)
             {
                 manifest.DependentGames = game.DependentGames.Select(g => g.Id).ToArray();

--- a/LANCommander.Server/Controllers/Api/GamesController.cs
+++ b/LANCommander.Server/Controllers/Api/GamesController.cs
@@ -124,7 +124,7 @@ namespace LANCommander.Server.Controllers.Api
                     .Include(g => g.MultiplayerModes)
                     .Include(g => g.Platforms)
                     .Include(g => g.Publishers)
-                    .Include(g => g.Redistributables)
+                    .Query(q => q.Include(d => d.Redistributables).ThenInclude(r => r.Scripts))
                     .Include(g => g.Scripts)
                     .Include(g => g.Tags)
                     .AsNoTracking()


### PR DESCRIPTION
This PR adds the redistributables to the GET api/Games/{id} route, with eager nested loading of the scripts. This allows the launcher to successfully install the redistributables scripts. Also, the PR adds the redistributable list into the manifest, making the launcher able to launch the scripts.