### PR TITLE
Corrected Auto-updater

### DIFF
--- a/LANCommander.Launcher.Services/UpdateService.cs
+++ b/LANCommander.Launcher.Services/UpdateService.cs
@@ -41,22 +41,25 @@ namespace LANCommander.Launcher.Services
 
             Logger?.LogInformation("Update version {Version} has been downloaded", version);
 
-            Logger?.LogInformation("New autoupdater is being extracted");
+            string processExecutable = "LANCommander.AutoUpdater.exe";
 
-            string processExecutable = String.Empty;
-
-            if (File.Exists("LANCommander.AutoUpdater.exe"))
-                processExecutable = "LANCommander.AutoUpdater.exe";
-            else if (File.Exists("LANCommander.AutoUpdater"))
+            if (File.Exists("LANCommander.AutoUpdater"))
                 processExecutable = "LANCommander.AutoUpdater";
+
+            Logger?.LogInformation("New autoupdater is being extracted");
 
             using (ZipArchive archive = ZipFile.OpenRead(path))
             {
+                Logger?.LogTrace("Looping entries");
                 foreach (ZipArchiveEntry entry in archive.Entries.Where(e => e.FullName == processExecutable))
                 {
-                    entry.ExtractToFile(Path.Combine(processExecutable, entry.FullName));
+                    entry.ExtractToFile(entry.FullName, true);
+                    Logger?.LogTrace("Extracted {Entry}", entry);
                 }
+                Logger?.LogTrace("Entries loop over");
             }
+
+            Logger?.LogInformation("Sarting Autoupdater");
 
             var process = new ProcessStartInfo();
 

--- a/LANCommander.Launcher/UI/Settings/Index.razor
+++ b/LANCommander.Launcher/UI/Settings/Index.razor
@@ -109,7 +109,9 @@
     {
         var updateVersion = await UpdateService.CheckForUpdateAsync();
 
-        if (updateVersion == null)
+        Logger.LogDebug("Checked for update: {UpdateVersion}", updateVersion.Version);
+
+        if (updateVersion.Version == null)
             MessageService.Success("You are on the latest version!");
     }
 

--- a/LANCommander.Server/Controllers/Api/LauncherController.cs
+++ b/LANCommander.Server/Controllers/Api/LauncherController.cs
@@ -30,7 +30,7 @@ namespace LANCommander.Server.Controllers.Api
         {
             var version = _versionProvider.GetCurrentVersion();
             var settings = SettingService.GetSettings();
-            var fileName = $"LANCommander.Launcher-Windows-x64-v{version}.zip";
+            var fileName = $"LANCommander.Launcher-Windows-x64-v{version.WithoutMetadata()}.zip";
             var path = Path.Combine(settings.Launcher.StoragePath, fileName);
 
             if (!System.IO.File.Exists(path) || !settings.Launcher.HostUpdates)

--- a/LANCommander.Server/Controllers/Api/LauncherController.cs
+++ b/LANCommander.Server/Controllers/Api/LauncherController.cs
@@ -65,7 +65,7 @@ namespace LANCommander.Server.Controllers.Api
                 {
                     response.UpdateAvailable = true;
                     response.Version = currentVersion.ToString();
-                    response.DownloadUrl = Url.Action(nameof(DownloadAsync));
+                    response.DownloadUrl = Url.Action("Download", "Launcher");
                 }
             }
 


### PR DESCRIPTION
This PR re-enables the auto-update feature for the client:

- Launcher was updated to correctly fetch the version
- Launcher is now extracting correctly the AutoUpdater
- Server is correctly displaying the Download URL while Checking for update (not yet used in the Launcher)
- Server is now correctly grabbing the correct zip without the version Metadata Identifiers to match the Releases filenames