### PR TITLE
Add localization support to launcher

### DIFF
--- a/LANCommander.Launcher.Models/Settings.cs
+++ b/LANCommander.Launcher.Models/Settings.cs
@@ -10,6 +10,7 @@ namespace LANCommander.Launcher.Models
         public const string DEFAULT_GAME_USERNAME = "Player";
 
         public int LaunchCount { get; set; } = 0;
+        public string Culture { get; set; } = "en-US";
 
         public DatabaseSettings Database { get; set; } = new DatabaseSettings();
         public AuthenticationSettings Authentication { get; set; } = new AuthenticationSettings();

--- a/LANCommander.Launcher.Services/LocalizationService.cs
+++ b/LANCommander.Launcher.Services/LocalizationService.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Resources;
+using LANCommander.Launcher.Models;
+
+namespace LANCommander.Launcher.Services
+{
+    public class LocalizationService
+    {
+        private readonly Settings _settings;
+        private readonly ResourceManager _resourceManager;
+
+        public LocalizationService()
+        {
+            _settings = SettingService.GetSettings();
+            _resourceManager = new ResourceManager("LANCommander.Launcher.Resources.SharedResources", typeof(LocalizationService).Assembly);
+            
+            var culture = new CultureInfo(_settings.Culture);
+            
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+        }
+
+        public string GetString(string key)
+        {
+            return _resourceManager.GetString(key) ?? key;
+        }
+
+        public string GetString(string key, params object[] args)
+        {
+            var format = _resourceManager.GetString(key) ?? key;
+            return string.Format(CultureInfo.CurrentCulture, format, args);
+        }
+
+        public string GetString(string key, CultureInfo culture)
+        {
+            return _resourceManager.GetString(key, culture) ?? key;
+        }
+
+        public string GetString(string key, CultureInfo culture, params object[] args)
+        {
+            var format = _resourceManager.GetString(key, culture) ?? key;
+            return string.Format(culture, format, args);
+        }
+    }
+} 

--- a/LANCommander.Launcher/App.razor
+++ b/LANCommander.Launcher/App.razor
@@ -1,11 +1,14 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly">
+﻿@using LANCommander.Launcher.Services
+@inject LocalizationService LocalizationService
+
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(UI.MainLayout)" />
     </Found>
     <NotFound>
-        <PageTitle>Not found</PageTitle>
+        <PageTitle>@LocalizationService.GetString("NotFound")</PageTitle>
         <LayoutView Layout="@typeof(UI.MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
+            <p role="alert">@LocalizationService.GetString("NotFoundMessage")</p>
         </LayoutView>
     </NotFound>
 </Router>

--- a/LANCommander.Launcher/LANCommander.Launcher.csproj
+++ b/LANCommander.Launcher/LANCommander.Launcher.csproj
@@ -5,6 +5,7 @@
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
 		<ApplicationIcon>LANCommanderDark.ico</ApplicationIcon>
 		<Company>LANCommander</Company>
 		<Product>Launcher</Product>
@@ -64,6 +65,7 @@
 	</ItemGroup>
   
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.0" />
         <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
         <PackageReference Include="nulastudio.NetBeauty" Version="2.1.4.6" />
         <PackageReference Include="Photino.Blazor" Version="4.0.13" />
@@ -83,6 +85,10 @@
         <ProjectReference Include="..\LANCommander.ServiceDefaults\LANCommander.ServiceDefaults.csproj" />
         <ProjectReference Include="..\LANCommander.UI\LANCommander.UI.csproj" />
     </ItemGroup>
+  
+      <ItemGroup>
+      <EmbeddedResource Include="Resources\**\*.resx" />
+  </ItemGroup>
 
 	<Target Name="CompileGlobalSass" BeforeTargets="Compile">
 		<Message Text="Compiling global SCSS files" Importance="high" />

--- a/LANCommander.Launcher/Program.cs
+++ b/LANCommander.Launcher/Program.cs
@@ -48,13 +48,14 @@ namespace LANCommander.Launcher
 #endif
                 .CreateLogger();
 
-            Logger?.Information($"Starting up launcher v{UpdateService.GetCurrentVersion()}...");
-            Logger?.Debug("Loading settings from file");
+            var localizationService = new LocalizationService();
+            Logger?.Information(localizationService.GetString("StartingUpLauncher", UpdateService.GetCurrentVersion()));
+            Logger?.Debug(localizationService.GetString("LoadingSettingsFromFile"));
 
             var builder = PhotinoBlazorAppBuilder.CreateDefault(args);
 
             #region Configure Logging
-            Logger?.Debug("Configuring logging...");
+            Logger?.Debug(localizationService.GetString("ConfiguringLogging"));
 
             builder.Services.AddLogging(loggingBuilder =>
             {
@@ -66,7 +67,7 @@ namespace LANCommander.Launcher
             
             builder.RootComponents.Add<App>("app");
 
-            Logger?.Debug("Registering services...");
+            Logger?.Debug(localizationService.GetString("RegisteringServices"));
 
             #region Aspire
             builder.Services.AddServiceDiscovery();
@@ -79,6 +80,7 @@ namespace LANCommander.Launcher
             
             builder.Services.AddCustomWindow();
             builder.Services.AddAntDesign();
+            builder.Services.AddSingleton<LocalizationService>();
             builder.Services.AddLANCommander(options =>
             {
                 options.ServerAddress = settings.Authentication.ServerAddress;
@@ -86,12 +88,12 @@ namespace LANCommander.Launcher
             });
 
             #region Build Application
-            Logger?.Debug("Building application...");
+            Logger?.Debug(localizationService.GetString("BuildingApplication"));
 
             var app = builder.Build();
 
             app.MainWindow
-                .SetTitle("LANCommander")
+                .SetTitle(localizationService.GetString("AppTitle"))
                 .SetChromeless(true)
                 .RegisterCustomSchemeHandler("media", (object sender, string scheme, string url, out string contentType) =>
                 {
@@ -117,7 +119,7 @@ namespace LANCommander.Launcher
                     }
                     catch (Exception ex)
                     {
-                        Logger?.Warning(ex, "Image not found locally");
+                        Logger?.Warning(ex, localizationService.GetString("ImageNotFoundLocally"));
 
                         contentType = "";
                     }
@@ -164,7 +166,7 @@ namespace LANCommander.Launcher
 
             AppDomain.CurrentDomain.UnhandledException += (sender, error) =>
             {
-                app.MainWindow.ShowMessage("Fatal exception", error.ExceptionObject.ToString());
+                app.MainWindow.ShowMessage(localizationService.GetString("FatalException"), error.ExceptionObject.ToString());
             };
 
             app.Services.InitializeLANCommander();
@@ -186,13 +188,13 @@ namespace LANCommander.Launcher
 
                 SettingService.SaveSettings(settings);
 
-                Logger?.Debug("Starting application...");
+                Logger?.Debug(localizationService.GetString("StartingApplication"));
 
                 app.MainWindow.WindowClosing += MainWindow_WindowClosing;
 
                 app.Run();
 
-                Logger?.Debug("Closing application...");
+                Logger?.Debug(localizationService.GetString("ClosingApplication"));
             }
         }
 

--- a/LANCommander.Launcher/Resources/SharedResources.de.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.de.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>Launcher abgestürzt</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Bibliothek neu importieren</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Mit Server neu verbinden</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Bibliothek anzeigen</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Du bist gestorben.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Neuer Name</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Import gestartet</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Depot durchsuchen</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Nach Updates suchen</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Download-Größe</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Installieren</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Benötigter Speicherplatz</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Add-ons</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Installationsort</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Handbuch</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Speicherstände verwalten</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Ändern</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Dateien durchsuchen</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Dateien validieren</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Entfernen</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Deinstallieren</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Installationsskripte ausführen</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Deinstallationsskripte ausführen</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Namensänderungsskripte ausführen</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Schlüsseländerungsskripte ausführen</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Problem melden</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>{0} installieren</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>{0} ändern</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Dateikonflikte</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Ausgewählte ersetzen</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Möchten Sie {0} wirklich deinstallieren? Alle lokalen Speicherstände werden gelöscht.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Möchten Sie {0} wirklich deinstallieren?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Spiel deinstallieren</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Spiel aus Bibliothek entfernen</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Absenden</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Basisspiel</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Zu entfernende Add-ons</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Spiel konnte nicht entfernt werden</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Problem gemeldet!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Unbekannter Fehler: Problem nicht gemeldet</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Erstellt am</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Sind Sie sicher? Dies wird alle lokalen Speicherstände ersetzen!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Sind Sie sicher, dass Sie diesen Speicherstand löschen möchten?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Hochladen</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Speicherstand heruntergeladen!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Speicherstand gelöscht!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Speicherstand hochgeladen!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Gruppieren nach</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Sortieren nach</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Genre</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Plattform</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Entwickler</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Herausgeber</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Spieler</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Minimum</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Installiert</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Anwenden</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Möchten Sie dieses Spiel stoppen?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Ja</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Läuft</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Startet</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Stoppt</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Spielen</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Keine Aktionen gefunden!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Keine primäre Aktion gefunden!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>{0} spielen</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importiere: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Import startet...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Mit {0} anmelden</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Anmeldung konnte nicht verarbeitet werden</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Verbindung verloren, versuche erneut...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Verbindung verloren, versuche erneut ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Server nicht verfügbar, Offline-Modus aktiviert</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Verbindung hergestellt!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>In Bearbeitung</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Als nächstes</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>Die Warteschlange ist leer</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>In Bibliothek anzeigen</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} wurde zu Ihrer Bibliothek hinzugefügt!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} konnte nicht zu Ihrer Bibliothek hinzugefügt werden!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Server-Adresse</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Benutzername</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Passwort</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Anmelden</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrieren</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>Oder</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Willkommen zurück!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Passwort bestätigen</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>Der Server scheint offline zu sein...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Server-Adresse</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Entdeckt</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Scanne</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Erneut scannen</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Keine Ergebnisse gefunden</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Filter zurücksetzen</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Nicht kategorisiert</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Spiele</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Speicherpfade</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Pfad hinzufügen</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Medien</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Speicherpfad</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Skript-Debugging aktivieren</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Protokollierungspfad</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Protokollierungsebene</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Einstellungen gespeichert!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Ein unbekannter Fehler ist aufgetreten.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>Sie haben die neueste Version!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>In Warteschlange</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installiert</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Deinstalliert</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Spielzeit</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Zuletzt gespielt</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Veröffentlicht am</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Installation fehlgeschlagen</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>Die Installation für {0} ist fehlgeschlagen. Download wiederholen?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Keine</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} Minuten</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} Stunden</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Nie</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Depot-Ergebnisse konnten nicht abgerufen werden</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Unerwarteter Fehler beim Abrufen der Depot-Ergebnisse</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Nicht gefunden</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Entschuldigung, es gibt nichts an dieser Adresse.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Keine Ergebnisse</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>Das Depot ist leer oder Sie sind nicht autorisiert. Kontaktieren Sie Ihren Administrator.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Aus Bibliothek entfernen</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Zur Bibliothek hinzufügen</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Sammlung</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Starte Launcher v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Lade Einstellungen aus Datei</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Konfiguriere Protokollierung...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Registriere Dienste...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Erstelle Anwendung...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Bild nicht lokal gefunden</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Fataler Fehler</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Starte Anwendung...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Schließe Anwendung...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Fehler in Zwischenablage kopiert!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>Wieder online!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Wiederverbindung nicht möglich!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Der LANCommander-Server konnte nicht erreicht werden. Möchten Sie sich abmelden und es erneut versuchen?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Abmelden</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Offline bleiben</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Namen ändern</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Zum Offline-Modus wechseln</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Sie sind derzeit offline</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Demnächst verfügbar!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Freunde</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Anmelden</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Quellspiel</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Möchten Sie {0} deinstallieren?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>Ein Update für v{0} ist verfügbar. Möchten Sie es herunterladen und installieren?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Jetzt aktualisieren</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Depot</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Import abgeschlossen</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Import fehlgeschlagen</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Später</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Launcher-Update</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Bibliothek</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Lokale Größe</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Verschieben</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Ursprüngliche Größe</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.es.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.es.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>El lanzador se ha estrellado</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Reimportar biblioteca</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Reconectar al servidor</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Ver biblioteca</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Has muerto.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Nuevo nombre</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Importación iniciada</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Conectar</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Explorar depósito</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Buscar actualizaciones</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Tamaño de descarga</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Espacio requerido</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Complementos</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Ubicación de instalación</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Manual</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Gestionar partidas guardadas</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modificar</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Explorar archivos</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Validar archivos</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Desinstalar</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Ejecutar scripts de instalación</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Ejecutar scripts de desinstalación</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Ejecutar scripts de cambio de nombre</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Ejecutar scripts de cambio de clave</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Reportar problema</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Instalar {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Modificar {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Conflictos de archivos</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Reemplazar seleccionados</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>¿Realmente quieres desinstalar {0}? Todas las partidas guardadas locales serán eliminadas.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>¿Realmente quieres desinstalar {0}?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Desinstalar juego</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Eliminar juego de la biblioteca</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Juego base</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Complementos a eliminar</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>No se pudo eliminar el juego</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>¡Problema reportado!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Error desconocido: problema no reportado</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Creado el</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>¿Estás seguro? ¡Esto reemplazará todas las partidas guardadas locales!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>¿Estás seguro de que quieres eliminar esta partida guardada?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Subir</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>¡Partida guardada descargada!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>¡Partida guardada eliminada!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>¡Partida guardada subida!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Título</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Agrupar por</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Ordenar por</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Motor</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Género</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Plataforma</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Desarrolladores</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Editores</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Jugadores</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Mínimo</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Máximo</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Instalado</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Aplicar</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>¿Quieres detener este juego?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Sí</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Ejecutándose</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Iniciando</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Deteniendo</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Jugar</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>¡No se encontraron acciones!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>¡No se encontró acción primaria!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Jugar {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importando: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Iniciando importación...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Iniciar sesión con {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>No se pudo procesar el inicio de sesión</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Conexión perdida, reintentando...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Conexión perdida, reintentando ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Servidor no disponible, habilitando modo offline</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>¡Conexión establecida!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>En progreso</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Próximo</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>La cola está vacía</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completado</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Ver en biblioteca</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>¡{0} ha sido añadido a tu biblioteca!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>¡{0} no pudo ser añadido a tu biblioteca!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Dirección del servidor</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nombre de usuario</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Contraseña</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Iniciar sesión</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrarse</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>O</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>¡Bienvenido de vuelta!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmar contraseña</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>El servidor parece estar offline...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Dirección del servidor</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Descubierto</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Escaneando</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Escanear de nuevo</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>No se encontraron resultados</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Restablecer filtro</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Sin categorizar</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Juegos</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Rutas de almacenamiento</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Añadir ruta</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Medios</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Ruta de almacenamiento</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Depuración</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Habilitar depuración de scripts</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Ruta de registro</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Nivel de registro</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>¡Configuración guardada!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Ha ocurrido un error desconocido.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>¡Tienes la versión más reciente!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Actualizar</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>En cola</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Instalando</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Desinstalando</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Tiempo de juego</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Última vez jugado</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Lanzado el</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Instalación fallida</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>La instalación para {0} ha fallado. ¿Reintentar descarga?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minutos</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} horas</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Nunca</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>No se pudieron obtener los resultados del depósito</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Error inesperado al obtener resultados del depósito</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>No encontrado</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Lo sentimos, no hay nada en esta dirección.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Sin resultados</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>El depósito está vacío o no estás autorizado. Contacta a tu administrador.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Eliminar de la biblioteca</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Añadir a la biblioteca</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Colección</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Iniciando lanzador v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Cargando configuración desde archivo</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Configurando registro...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Registrando servicios...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Construyendo aplicación...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Imagen no encontrada localmente</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Excepción fatal</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Iniciando aplicación...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Cerrando aplicación...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>¡Error copiado al portapapeles!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>¡De vuelta en línea!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>¡No se pudo reconectar!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>No se pudo alcanzar el servidor LANCommander. ¿Quieres cerrar sesión e intentarlo de nuevo?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Permanecer offline</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Cambiar nombre</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Cambiar a modo offline</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Actualmente estás offline</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>¡Próximamente!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Amigos</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Descargas</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Depósito</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Iniciar sesión</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Juego fuente</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>¿Quieres desinstalar {0}?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>Hay una actualización disponible para la versión {0}. ¿Quieres descargarla e instalarla?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Actualizar ahora</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Importación completada</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Importación fallida</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Más tarde</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Actualización del lanzador</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Biblioteca</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Tamaño local</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Mover</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Nombre</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Tamaño original</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.fr.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.fr.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>Le lanceur a planté</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Réimporter la bibliothèque</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Se reconnecter au serveur</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Voir la bibliothèque</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Vous êtes mort.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Nouveau nom</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Importation commencée</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Se connecter</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Parcourir le dépôt</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Vérifier les mises à jour</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Taille du téléchargement</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Installer</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Espace requis</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Extensions</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Emplacement d'installation</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Manuel</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Gérer les sauvegardes</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modifier</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Parcourir les fichiers</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Valider les fichiers</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Supprimer</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Désinstaller</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Exécuter les scripts d'installation</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Exécuter les scripts de désinstallation</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Exécuter les scripts de changement de nom</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Exécuter les scripts de changement de clé</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Signaler un problème</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Installer {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Modifier {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Conflits de fichiers</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Remplacer la sélection</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Voulez-vous vraiment désinstaller {0} ? Toutes les sauvegardes locales seront supprimées.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Voulez-vous vraiment désinstaller {0} ?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Désinstaller le jeu</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuler</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Retirer le jeu de la bibliothèque</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Soumettre</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Jeu de base</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Extensions à supprimer</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Impossible de supprimer le jeu</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Problème signalé !</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Erreur inconnue : problème non signalé</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Créé le</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Êtes-vous sûr ? Cela remplacera toutes les sauvegardes locales !</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Êtes-vous sûr de vouloir supprimer cette sauvegarde ?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Sauvegarde téléchargée !</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Sauvegarde supprimée !</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Sauvegarde téléchargée !</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Titre</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Grouper par</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Trier par</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Moteur</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Genre</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Étiquette</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Plateforme</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Développeurs</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Éditeurs</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Joueurs</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Minimum</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Installé</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Voulez-vous arrêter ce jeu ?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Oui</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>En cours</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Démarrage</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Arrêt</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Jouer</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Aucune action trouvée !</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Aucune action primaire trouvée !</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Jouer à {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importation : {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Démarrage de l'importation...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Se connecter avec {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Impossible de traiter la connexion</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Connexion perdue, nouvelle tentative...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Connexion perdue, nouvelle tentative ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Serveur indisponible, activation du mode hors ligne</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Connexion établie !</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>En cours</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Suivant</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>La file d'attente est vide</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Terminé</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Voir dans la bibliothèque</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} a été ajouté à votre bibliothèque !</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} n'a pas pu être ajouté à votre bibliothèque !</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Adresse du serveur</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nom d'utilisateur</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Se connecter</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>S'inscrire</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>Ou</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Bon retour !</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmer le mot de passe</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>Le serveur semble être hors ligne...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Adresse du serveur</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Hors ligne</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Découvert</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Analyse</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Réanalyser</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Aucun résultat trouvé</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Réinitialiser le filtre</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Non catégorisé</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Enregistrer</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Jeux</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Chemins de stockage</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Ajouter un chemin</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Médias</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Chemin de stockage</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Débogage</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Activer le débogage des scripts</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Chemin de journalisation</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Niveau de journalisation</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Paramètres enregistrés !</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Une erreur inconnue s'est produite.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>Vous avez la dernière version !</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Mettre à jour</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>En file d'attente</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installation</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Désinstallation</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Temps de jeu</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Dernière partie</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Sorti le</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Échec de l'installation</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>L'installation pour {0} a échoué. Réessayer le téléchargement ?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minutes</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} heures</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Jamais</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Impossible de récupérer les résultats du dépôt</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Erreur inattendue lors de la récupération des résultats du dépôt</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Non trouvé</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Désolé, il n'y a rien à cette adresse.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Aucun résultat</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>Le dépôt est vide ou vous n'êtes pas autorisé. Contactez votre administrateur.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Retirer de la bibliothèque</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Ajouter à la bibliothèque</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Collection</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Étiquette</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Démarrage du lanceur v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Chargement des paramètres depuis le fichier</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Configuration de la journalisation...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Enregistrement des services...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Construction de l'application...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Image non trouvée localement</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Exception fatale</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Démarrage de l'application...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Fermeture de l'application...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Erreur copiée dans le presse-papiers !</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>De retour en ligne !</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Impossible de se reconnecter !</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Impossible d'atteindre le serveur LANCommander. Voulez-vous vous déconnecter et réessayer ?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Se déconnecter</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Rester hors ligne</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Changer le nom</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Passer en mode hors ligne</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Vous êtes actuellement hors ligne</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Bientôt disponible !</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Amis</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Téléchargements</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Dépôt</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Paramètres</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Se connecter</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Jeu source</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Souhaitez-vous désinstaller {0}?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>Une mise à jour pour la version {0} est disponible. Voulez-vous la télécharger et l'installer ?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Mettre à jour maintenant</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Importation terminée</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Importation échouée</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Plus tard</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Mise à jour du lanceur</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Bibliothèque</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Taille locale</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Déplacer</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Taille originale</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.it.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.it.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>Il launcher si è bloccato</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Reimporta libreria</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Riconnetti al server</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Visualizza libreria</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Sei morto.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Nuovo nome</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Importazione iniziata</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Connetti</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Sfoglia deposito</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Controlla aggiornamenti</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Dimensione download</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Installa</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Spazio richiesto</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Add-on</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Posizione installazione</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Manuale</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Gestisci salvataggi</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modifica</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Sfoglia file</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Valida file</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Rimuovi</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Disinstalla</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Esegui script di installazione</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Esegui script di disinstallazione</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Esegui script di cambio nome</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Esegui script di cambio chiave</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Segnala problema</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Installa {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Modifica {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Conflitti file</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Sostituisci selezionati</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Vuoi davvero disinstallare {0}? Tutti i salvataggi locali saranno eliminati.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Vuoi davvero disinstallare {0}?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Disinstalla gioco</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annulla</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Rimuovi gioco dalla libreria</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Invia</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Gioco base</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Add-on da rimuovere</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Impossibile rimuovere il gioco</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Problema segnalato!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Errore sconosciuto: problema non segnalato</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Creato il</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Sei sicuro? Questo sostituirà tutti i salvataggi locali!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare questo salvataggio?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Carica</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Salvataggio scaricato!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Salvataggio eliminato!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Salvataggio caricato!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Titolo</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Raggruppa per</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Ordina per</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Motore</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Genere</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Piattaforma</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Sviluppatori</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Editori</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Giocatori</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Minimo</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Massimo</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Installato</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Applica</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Vuoi fermare questo gioco?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Sì</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>In esecuzione</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Avvio</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Arresto</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Gioca</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Nessuna azione trovata!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Nessuna azione primaria trovata!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Gioca a {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importazione: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Avvio importazione...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Accedi con {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Impossibile elaborare l'accesso</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Connessione persa, nuovo tentativo...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Connessione persa, nuovo tentativo ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Server non disponibile, attivazione modalità offline</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Connessione stabilita!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>In corso</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Prossimo</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>La coda è vuota</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completato</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Visualizza in libreria</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} è stato aggiunto alla tua libreria!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} non ha potuto essere aggiunto alla tua libreria!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Indirizzo server</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nome utente</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Accedi</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrati</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>O</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Bentornato!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Conferma password</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>Il server sembra essere offline...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Indirizzo server</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Scoperto</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Scansione</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Riscansione</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Nessun risultato trovato</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Ripristina filtro</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Non categorizzato</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Giochi</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Percorsi di archiviazione</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Aggiungi percorso</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Media</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Percorso di archiviazione</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Abilita debug script</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Percorso di registrazione</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Livello di registrazione</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Impostazioni salvate!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Si è verificato un errore sconosciuto.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>Hai l'ultima versione!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Aggiorna</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>In coda</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installazione</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Disinstallazione</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Tempo di gioco</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Ultima partita</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Pubblicato il</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Installazione fallita</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>L'installazione per {0} è fallita. Riprovare il download?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Nessuno</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minuti</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} ore</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Mai</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Impossibile recuperare i risultati del deposito</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Errore imprevisto nel recupero dei risultati del deposito</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Non trovato</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Spiacenti, non c'è nulla a questo indirizzo.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Nessun risultato</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>Il deposito è vuoto o non sei autorizzato. Contatta il tuo amministratore.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Rimuovi dalla libreria</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Aggiungi alla libreria</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Collezione</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Avvio launcher v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Caricamento impostazioni dal file</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Configurazione registrazione...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Registrazione servizi...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Compilazione applicazione...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Immagine non trovata localmente</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Eccezione fatale</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Avvio applicazione...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Chiusura applicazione...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Errore copiato negli appunti!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>Di nuovo online!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Impossibile riconnettersi!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Impossibile raggiungere il server LANCommander. Vuoi disconnetterti e riprovare?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Disconnetti</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Rimani offline</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Cambia nome</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Passa alla modalità offline</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Sei attualmente offline</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Prossimamente disponibile!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Amici</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Deposito</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Accedi</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Gioco di origine</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Vuoi disinstallare {0}?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>È disponibile un aggiornamento per v{0}. Vuoi scaricarlo e installarlo?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Aggiorna ora</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Importazione completata</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Importazione fallita</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Più tardi</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Aggiornamento launcher</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Libreria</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Dimensione locale</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Sposta</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Dimensione originale</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.ja.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.ja.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>ランチャーがクラッシュしました</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>ライブラリを再インポート</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>サーバーに再接続</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>ライブラリを表示</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>あなたは死にました。</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>新しい名前</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>インポート開始</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>接続</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>デポを閲覧</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>アップデートを確認</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>ダウンロードサイズ</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>インストール</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>閉じる</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>必要な容量</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>アドオン</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>インストール場所</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>マニュアル</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>セーブデータを管理</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>変更</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>ファイルを閲覧</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>ファイルを検証</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>削除</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>アンインストール</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>インストールスクリプトを実行</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>アンインストールスクリプトを実行</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>名前変更スクリプトを実行</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>キー変更スクリプトを実行</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>問題を報告</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>{0}をインストール</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>{0}を変更</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>ファイルの競合</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>選択されたものを置換</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>本当に{0}をアンインストールしますか？すべてのローカルセーブデータが削除されます。</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>本当に{0}をアンインストールしますか？</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>ゲームをアンインストール</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>キャンセル</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>ライブラリからゲームを削除</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>送信</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>ベースゲーム</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>削除するアドオン</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>ゲームを削除できませんでした</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>問題が報告されました！</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>不明なエラー：問題が報告されていません</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>作成日</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>本当ですか？これによりすべてのローカルセーブデータが置換されます！</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>このセーブデータを削除してもよろしいですか？</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>アップロード</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>セーブデータがダウンロードされました！</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>セーブデータが削除されました！</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>セーブデータがアップロードされました！</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>タイトル</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>グループ化</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>並び替え</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>エンジン</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>ジャンル</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>タグ</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>プラットフォーム</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>開発者</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>パブリッシャー</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>プレイヤー数</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>最小</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>最大</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>インストール済み</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>適用</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>このゲームを停止しますか？</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>はい</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>実行中</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>開始中</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>停止中</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>プレイ</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>アクションが見つかりません！</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>プライマリアクションが見つかりません！</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>{0}をプレイ</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>インポート中：{0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>インポート開始中...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>{0}でサインイン</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>ログインを処理できませんでした</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>接続が失われました、再試行中...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>接続が失われました、再試行中（{0}/{1}）...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>サーバーが利用できません、オフラインモードを有効化</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>接続が確立されました！</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>進行中</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>次</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>キューが空です</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>完了</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>ライブラリで表示</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0}がライブラリに追加されました！</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0}をライブラリに追加できませんでした！</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>サーバーアドレス</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>ユーザー名</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>パスワード</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>ログイン</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>登録</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>または</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>おかえりなさい！</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>パスワードを確認</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>サーバーがオフラインのようです...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>サーバーアドレス</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>オフライン</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>発見済み</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>スキャン中</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>再スキャン</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>結果が見つかりません</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>フィルターをリセット</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>未分類</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>ゲーム</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>ストレージパス</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>パスを追加</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>メディア</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>ストレージパス</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>デバッグ</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>スクリプトデバッグを有効化</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>ログパス</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>ログレベル</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>設定が保存されました！</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>不明なエラーが発生しました。</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>最新バージョンです！</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>キュー中</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>インストール中</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>アンインストール中</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>プレイ時間</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>最後にプレイ</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>リリース日</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>インストールに失敗</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>{0}のインストールに失敗しました。ダウンロードを再試行しますか？</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0}分</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0}時間</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>一度も</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>デポの結果を取得できませんでした</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>デポの結果を取得中に予期しないエラーが発生しました</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>見つかりません</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>申し訳ございませんが、このアドレスには何もありません。</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>結果なし</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>デポが空であるか、権限がありません。管理者にお問い合わせください。</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>ライブラリから削除</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>ライブラリに追加</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>コレクション</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>タグ</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>ランチャーv{0}を起動中...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>ファイルから設定を読み込み中</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>ログ設定中...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>サービス登録中...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>アプリケーション構築中...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>画像がローカルに見つかりません</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>致命的な例外</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>アプリケーション起動中...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>アプリケーション終了中...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>エラーがクリップボードにコピーされました！</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>オンラインに戻りました！</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>再接続できませんでした！</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>LANCommanderサーバーに到達できません。ログアウトして再試行しますか？</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>ログアウト</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>オフラインのまま</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>名前を変更</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>オフラインモードに切り替え</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>現在オフラインです</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>近日公開！</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>フレンド</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>ダウンロード</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>デポ</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>設定</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>サインイン</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>ソースゲーム</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>{0} をアンインストールしますか?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>v{0} のアップデートが利用可能です。ダウンロードしてインストールしますか?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>今すぐアップデート</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>インポート完了</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>インポート失敗</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>後で</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>ランチャーアップデート</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>ライブラリ</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>ローカルサイズ</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>移動</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>名前</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>元のサイズ</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.ko.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.ko.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>런처가 충돌했습니다</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>라이브러리 다시 가져오기</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>서버에 다시 연결</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>라이브러리 보기</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>당신은 죽었습니다.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>새 이름</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>가져오기 시작됨</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>연결</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>저장소 탐색</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>업데이트 확인</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>다운로드 크기</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>설치</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>닫기</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>필요한 공간</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>애드온</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>설치 위치</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>매뉴얼</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>저장 파일 관리</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>수정</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>파일 탐색</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>파일 검증</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>제거</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>제거</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>설치 스크립트 실행</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>제거 스크립트 실행</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>이름 변경 스크립트 실행</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>키 변경 스크립트 실행</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>문제 신고</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>{0} 설치</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>{0} 수정</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>파일 충돌</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>선택된 항목 교체</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>정말로 {0}을(를) 제거하시겠습니까? 모든 로컬 저장 파일이 삭제됩니다.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>정말로 {0}을(를) 제거하시겠습니까?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>게임 제거</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>취소</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>라이브러리에서 게임 제거</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>제출</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>기본 게임</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>제거할 애드온</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>게임을 제거할 수 없습니다</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>문제가 신고되었습니다!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>알 수 없는 오류: 문제가 신고되지 않음</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>생성일</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>정말입니까? 이렇게 하면 모든 로컬 저장 파일이 교체됩니다!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>이 저장 파일을 삭제하시겠습니까?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>업로드</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>저장 파일이 다운로드되었습니다!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>저장 파일이 삭제되었습니다!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>저장 파일이 업로드되었습니다!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>제목</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>그룹화 기준</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>정렬 기준</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>엔진</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>장르</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>태그</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>플랫폼</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>개발사</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>배급사</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>플레이어 수</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>최소</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>최대</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>설치됨</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>적용</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>이 게임을 중지하시겠습니까?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>예</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>실행 중</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>시작 중</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>중지 중</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>게임</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>작업을 찾을 수 없습니다!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>주요 작업을 찾을 수 없습니다!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>{0} 게임</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>가져오는 중: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>가져오기 시작 중...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>{0}로 로그인</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>로그인을 처리할 수 없습니다</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>연결이 끊어졌습니다, 재시도 중...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>연결이 끊어졌습니다, 재시도 중 ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>서버를 사용할 수 없습니다, 오프라인 모드 활성화</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>연결이 설정되었습니다!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>진행 중</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>다음</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>큐가 비어 있습니다</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>완료됨</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>라이브러리에서 보기</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0}이(가) 라이브러리에 추가되었습니다!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0}을(를) 라이브러리에 추가할 수 없습니다!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>서버 주소</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>사용자 이름</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>비밀번호</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>로그인</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>등록</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>또는</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>다시 오신 것을 환영합니다!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>비밀번호 확인</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>서버가 오프라인인 것 같습니다...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>서버 주소</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>오프라인</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>발견됨</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>스캔 중</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>다시 스캔</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>결과를 찾을 수 없습니다</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>필터 재설정</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>분류되지 않음</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>저장</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>게임</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>저장소 경로</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>경로 추가</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>미디어</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>저장소 경로</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>디버그</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>스크립트 디버깅 활성화</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>로깅 경로</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>로깅 수준</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>설정이 저장되었습니다!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>알 수 없는 오류가 발생했습니다.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>최신 버전을 사용하고 있습니다!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>업데이트</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>대기 중</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>설치 중</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>제거 중</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>게임 시간</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>마지막 게임</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>출시일</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>설치 실패</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>{0}의 설치가 실패했습니다. 다운로드를 다시 시도하시겠습니까?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>없음</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0}분</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0}시간</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>한 번도</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>저장소 결과를 가져올 수 없습니다</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>저장소 결과를 가져오는 중 예기치 않은 오류가 발생했습니다</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>찾을 수 없음</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>죄송합니다. 이 주소에는 아무것도 없습니다.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>결과 없음</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>저장소가 비어 있거나 권한이 없습니다. 관리자에게 문의하세요.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>라이브러리에서 제거</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>라이브러리에 추가</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>컬렉션</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>태그</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>런처 v{0} 시작 중...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>파일에서 설정 로드 중</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>로깅 구성 중...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>서비스 등록 중...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>애플리케이션 빌드 중...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>로컬에서 이미지를 찾을 수 없습니다</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>치명적인 예외</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>애플리케이션 시작 중...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>애플리케이션 종료 중...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>오류가 클립보드에 복사되었습니다!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>다시 온라인!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>다시 연결할 수 없습니다!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>LANCommander 서버에 도달할 수 없습니다. 로그아웃하고 다시 시도하시겠습니까?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>로그아웃</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>오프라인 유지</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>이름 변경</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>오프라인 모드로 전환</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>현재 오프라인입니다</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>곧 출시!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>친구</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>다운로드</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>정거장</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>설정</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>로그인</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>소스 게임</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>{0}을(를) 제거하시겠습니까?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>v{0}에 대한 업데이트가 있습니다. 다운로드하여 설치하시겠습니까?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>지금 업데이트</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>가져오기 완료</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>가져오기 실패</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>나중에</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>런처 업데이트</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>라이브러리</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>로컬 크기</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>이동</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>이름</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>원본 크기</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.nl.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.nl.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>De launcher is gecrashed</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Bibliotheek opnieuw importeren</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Opnieuw verbinden met server</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Bibliotheek bekijken</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Je bent gestorven.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Nieuwe naam</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Import gestart</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Verbinden</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Depot doorbladeren</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Controleren op updates</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Downloadgrootte</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Installeren</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Sluiten</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Benodigde ruimte</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Add-ons</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Installatielocatie</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Handleiding</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Spelstanden beheren</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Wijzigen</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Bestanden doorbladeren</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Bestanden valideren</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Installatiescripts uitvoeren</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Verwijderingsscripts uitvoeren</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Naamwijzigingsscripts uitvoeren</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Sleutelwijzigingsscripts uitvoeren</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Probleem melden</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>{0} installeren</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>{0} wijzigen</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Bestandsconflicten</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Geselecteerde vervangen</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Wil je {0} echt verwijderen? Alle lokale spelstanden worden gewist.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Wil je {0} echt verwijderen?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Spel verwijderen</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Annuleren</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Spel uit bibliotheek verwijderen</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Versturen</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Basisspel</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Te verwijderen add-ons</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Kon het spel niet verwijderen</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Probleem gemeld!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Onbekende fout: probleem niet gemeld</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Aangemaakt op</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Weet je het zeker? Dit vervangt alle lokale spelstanden!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Weet je zeker dat je deze spelstand wilt verwijderen?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Uploaden</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Spelstand gedownload!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Spelstand verwijderd!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Spelstand geüpload!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Titel</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Groeperen op</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Sorteren op</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Genre</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Ontwikkelaars</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Uitgevers</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Spelers</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Minimum</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Geïnstalleerd</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Toepassen</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Wil je dit spel stoppen?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Ja</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Draait</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Start</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Stopt</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Spelen</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Geen acties gevonden!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Geen primaire actie gevonden!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>{0} spelen</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importeren: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Import starten...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Inloggen met {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Kon de login niet verwerken</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Verbinding verloren, opnieuw proberen...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Verbinding verloren, opnieuw proberen ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Server niet beschikbaar, offline modus inschakelen</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Verbinding tot stand gebracht!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>Bezig</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Volgende</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>De wachtrij is leeg</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Voltooid</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Bekijken in bibliotheek</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} is toegevoegd aan je bibliotheek!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} kon niet worden toegevoegd aan je bibliotheek!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Serveradres</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Gebruikersnaam</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Wachtwoord</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Inloggen</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registreren</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>Of</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Welkom terug!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Wachtwoord bevestigen</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>De server lijkt offline te zijn...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Serveradres</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Ontdekt</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Scannen</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Opnieuw scannen</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Geen resultaten gevonden</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Filter resetten</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Niet gecategoriseerd</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Opslaan</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Spellen</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Opslagpaden</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Pad toevoegen</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Media</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Opslagpad</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Script debugging inschakelen</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Loggingpad</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Loggingniveau</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Instellingen opgeslagen!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Er is een onbekende fout opgetreden.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>Je hebt de nieuwste versie!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Bijwerken</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>In wachtrij</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installeren</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Verwijderen</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Speeltijd</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Laatst gespeeld</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Uitgebracht op</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Installatie mislukt</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>De installatie voor {0} is mislukt. Download opnieuw proberen?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Geen</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minuten</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} uren</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Nooit</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Kon depotresultaten niet ophalen</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Onverwachte fout bij ophalen depotresultaten</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Niet gevonden</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Sorry, er is niets op dit adres.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Geen resultaten</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>Het depot is leeg of je bent niet geautoriseerd. Neem contact op met je beheerder.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Uit bibliotheek verwijderen</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Toevoegen aan bibliotheek</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Verzameling</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Launcher v{0} opstarten...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Instellingen uit bestand laden</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Logging configureren...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Services registreren...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Applicatie bouwen...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Afbeelding lokaal niet gevonden</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Fatale uitzondering</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Applicatie opstarten...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Applicatie sluiten...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Fout gekopieerd naar klembord!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>Weer online!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Kon niet opnieuw verbinden!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Kon de LANCommander-server niet bereiken. Wil je uitloggen en opnieuw proberen?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Uitloggen</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Offline blijven</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Naam wijzigen</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Overschakelen naar offline modus</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Je bent momenteel offline</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Binnenkort beschikbaar!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Vrienden</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Instellingen</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Log in</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Bron spel</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Wil je {0} verwijderen?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>Er is een update voor v{0} beschikbaar. Wilt u deze downloaden en installeren?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Nu bijwerken</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Depot</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Import voltooid</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Import mislukt</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Later</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Launcher update</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Bibliotheek</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Lokale grootte</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Verplaatsen</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Naam</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Originele grootte</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.pt.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.pt.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>O launcher travou</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Reimportar biblioteca</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Reconectar ao servidor</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Ver biblioteca</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Você morreu.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Novo nome</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Importação iniciada</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Conectar</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Navegar pelo depósito</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Verificar atualizações</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Tamanho do download</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Instalar</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fechar</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Espaço necessário</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Complementos</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Local de instalação</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Manual</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Gerenciar salvamentos</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modificar</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Navegar pelos arquivos</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Validar arquivos</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Remover</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Desinstalar</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Executar scripts de instalação</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Executar scripts de desinstalação</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Executar scripts de mudança de nome</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Executar scripts de mudança de chave</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Reportar problema</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Instalar {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Modificar {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Conflitos de arquivo</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Substituir selecionados</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Você realmente quer desinstalar {0}? Todos os salvamentos locais serão excluídos.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Você realmente quer desinstalar {0}?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Desinstalar jogo</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Remover jogo da biblioteca</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Jogo base</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Complementos para remover</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Não foi possível remover o jogo</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Problema reportado!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Erro desconhecido: problema não reportado</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Criado em</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Tem certeza? Isso substituirá todos os salvamentos locais!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Tem certeza de que quer excluir este salvamento?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Enviar</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Salvamento baixado!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Salvamento excluído!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Salvamento enviado!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Título</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Agrupar por</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Ordenar por</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Motor</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Gênero</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Plataforma</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Desenvolvedores</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Editores</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Jogadores</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Mínimo</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Máximo</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Instalado</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Aplicar</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Você quer parar este jogo?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Sim</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Executando</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Iniciando</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Parando</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Jogar</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Nenhuma ação encontrada!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Nenhuma ação primária encontrada!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Jogar {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importando: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Iniciando importação...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Entrar com {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Não foi possível processar o login</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Conexão perdida, tentando novamente...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Conexão perdida, tentando novamente ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Servidor indisponível, ativando modo offline</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Conexão estabelecida!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>Em andamento</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Próximo</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>A fila está vazia</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Concluído</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Ver na biblioteca</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} foi adicionado à sua biblioteca!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} não pôde ser adicionado à sua biblioteca!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Endereço do servidor</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Nome de usuário</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Senha</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Entrar</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Registrar</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>Ou</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Bem-vindo de volta!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmar senha</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>O servidor parece estar offline...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Endereço do servidor</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Descoberto</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Escaneando</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Escanear novamente</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Nenhum resultado encontrado</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Redefinir filtro</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Sem categoria</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Salvar</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Jogos</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Caminhos de armazenamento</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Adicionar caminho</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Mídia</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Caminho de armazenamento</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Depuração</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Ativar depuração de scripts</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Caminho de registro</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Nível de registro</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Configurações salvas!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Ocorreu um erro desconhecido.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>Você tem a versão mais recente!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Atualizar</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>Na fila</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Instalando</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Desinstalando</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Tempo de jogo</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Última vez jogado</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Lançado em</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Falha na instalação</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>A instalação para {0} falhou. Tentar download novamente?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minutos</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} horas</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Nunca</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Não foi possível buscar os resultados do depósito</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Erro inesperado ao buscar resultados do depósito</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Não encontrado</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Desculpe, não há nada neste endereço.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Nenhum resultado</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>O depósito está vazio ou você não está autorizado. Entre em contato com seu administrador.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Remover da biblioteca</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Adicionar à biblioteca</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Coleção</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Iniciando launcher v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Carregando configurações do arquivo</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Configurando registro...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Registrando serviços...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Construindo aplicação...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Imagem não encontrada localmente</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Exceção fatal</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Iniciando aplicação...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Fechando aplicação...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Erro copiado para a área de transferência!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>De volta online!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Não foi possível reconectar!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Não foi possível alcançar o servidor LANCommander. Você quer fazer logout e tentar novamente?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Fazer logout</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Permanecer offline</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Alterar nome</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Alternar para modo offline</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Você está atualmente offline</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Em breve!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Amigos</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Depósito</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configurações</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Entrar</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Jogo fonte</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Você gostaria de desinstalar {0}?</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>Uma atualização para a versão v{0} está disponível. Deseja baixar e instalar?</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Atualizar agora</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Importação concluída</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Importação falhou</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Mais tarde</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Atualização do launcher</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Biblioteca</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Tamanho local</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Mover</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Tamanho original</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.resx
@@ -1,0 +1,639 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>Launcher Crashed</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>View Library</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Re-import library</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Reconnect to server</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Change Name</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Switch to offline mode</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Logout</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Download Size</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Space Required</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Addons</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Install Location</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Install</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Move</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modify</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>Back Online!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Could Not Reconnect!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>The LANCommander server could not be reached. Click stay offline and try later, or logout and enter your credentials.</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Stay Offline</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Error copied to clipboard!</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Fatal exception</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Starting up launcher v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Loading settings from file</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Configuring logging...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Registering services...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Building application...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Image not found locally</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Starting application...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Closing application...</value>
+  </data>
+  <data name="CompilingGlobalSassFiles" xml:space="preserve">
+    <value>Compiling global SCSS files</value>
+  </data>
+  <data name="CrashQuip_YouDied" xml:space="preserve">
+    <value>You Died.</value>
+  </data>
+  <data name="CrashQuip_Snake" xml:space="preserve">
+    <value>Snake? SNAAAAAAKE!</value>
+  </data>
+  <data name="CrashQuip_Wasted" xml:space="preserve">
+    <value>WASTED</value>
+  </data>
+  <data name="CrashQuip_MajorFracture" xml:space="preserve">
+    <value>Major fracture detected</value>
+  </data>
+  <data name="CrashQuip_PastIsGapingHole" xml:space="preserve">
+    <value>The past is a gaping hole. You try to run from it, but the more you run, the deeper, the darker, the bigger it gets.</value>
+  </data>
+  <data name="CrashQuip_TownCenterDestroyed" xml:space="preserve">
+    <value>Your town center has been destroyed</value>
+  </data>
+  <data name="CrashQuip_ForcesUnderAttack" xml:space="preserve">
+    <value>Your forces are under attack!</value>
+  </data>
+  <data name="CrashQuip_LostLead" xml:space="preserve">
+    <value>You have lost the lead</value>
+  </data>
+  <data name="CrashQuip_TerroristsWin" xml:space="preserve">
+    <value>Terrorists Win</value>
+  </data>
+  <data name="CrashQuip_WarNeverChanges" xml:space="preserve">
+    <value>War... War never changes.</value>
+  </data>
+  <data name="CrashQuip_DiedOfDysentery" xml:space="preserve">
+    <value>You have died of dysentery</value>
+  </data>
+  <data name="CrashQuip_FailedToRestoreBooks" xml:space="preserve">
+    <value>You have failed to restore the books. The Ages are lost.</value>
+  </data>
+  <data name="CrashQuip_PlayerSplattered" xml:space="preserve">
+    <value>Player was splattered by a demon</value>
+  </data>
+  <data name="CrashQuip_BlameISP" xml:space="preserve">
+    <value>Sure, blame it on your ISP</value>
+  </data>
+  <data name="CrashQuip_BabaNoMore" xml:space="preserve">
+    <value>Baba is no more</value>
+  </data>
+  <data name="CrashQuip_GuestsLost" xml:space="preserve">
+    <value>Guests are complaining they are lost</value>
+  </data>
+  <data name="CrashQuip_DarknessOvercome" xml:space="preserve">
+    <value>The darkness has overcome you</value>
+  </data>
+  <data name="CrashQuip_GordonFreemanTerminated" xml:space="preserve">
+    <value>Subject: Gordon Freeman. Status: Terminated</value>
+  </data>
+  <data name="CrashQuip_MissionFailedSpotted" xml:space="preserve">
+    <value>Mission failed: You were spotted.</value>
+  </data>
+  <data name="CrashQuip_CriticalDamageEject" xml:space="preserve">
+    <value>Critical damage! Eject, eject!</value>
+  </data>
+  <data name="CrashQuip_MinionsUnhappy" xml:space="preserve">
+    <value>Your minions are unhappy. They are leaving.</value>
+  </data>
+  <data name="CrashQuip_EmpireTriumphed" xml:space="preserve">
+    <value>The Empire has triumphed</value>
+  </data>
+  <data name="CrashQuip_QuestEndedFailure" xml:space="preserve">
+    <value>Your quest has ended in failure</value>
+  </data>
+  <data name="CrashQuip_EatenByGrue" xml:space="preserve">
+    <value>You have been eaten by a grue</value>
+  </data>
+  <data name="CrashQuip_NoMessWithLoWang" xml:space="preserve">
+    <value>You no mess with Lo Wang!</value>
+  </data>
+  <data name="CrashQuip_SamKilled" xml:space="preserve">
+    <value>Sam was killed. Serious carnage ensues.</value>
+  </data>
+  <data name="CrashQuip_AlienBastardsPay" xml:space="preserve">
+    <value>Damn, those alien bastards are gonna pay for shooting up my ride</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Manual</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Manage Saves</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Modify</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Browse Files</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Validate Files</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Run Install Scripts</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Run Uninstall Scripts</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Run Name Change Scripts</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Run Key Change Scripts</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Report Issue</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Install {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Modify {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>File Conflicts</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Replace Selected</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Uninstall</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>Would you like to uninstall {0}?</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Would you like to uninstall {0}? Your save files have been uploaded to the server.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Would you like to uninstall {0}? Your save files may be unrecoverable if they are contained within the game's install directory.</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Remove game from library</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Submit</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Library</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Depot</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>You are currently offline</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Downloads</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Coming soon!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Friends</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Created" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="Modified" xml:space="preserve">
+    <value>Modified</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Local Size</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Original Size</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>Source Game</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Base Game</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Addons to remove</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Could not remove game</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Issue reported!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Unknown error: issue not reported</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>New Name</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Created On</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Are you sure? This will replace any local save files!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Are you sure you want to delete this save?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Save downloaded!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Save deleted!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Save uploaded!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Title</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Group By</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Sort By</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Engine</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Genre</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Platform</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Developers</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Publishers</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Players</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Minimum</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Installed</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Do you want to stop this game?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Running</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Starting</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Stopping</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Play</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>No actions found!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>No primary action found!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Play {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Importing: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Starting import...</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>In Progress</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Up Next</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Completed</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>The queue is empty</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>View in Library</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>Update Now</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Later</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Launcher Update</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>An update for v{0} is available. Do you want to download and install?</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Sign in using {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Could not process login</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>Lost connection, retrying...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>Lost connection, retrying ({0}/{1}) ...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Server unavailable, enabling offline mode</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>Connection established!</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Import Started</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Import Complete</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Import Failed</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>Sign In</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Server Address</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Username</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Login</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Register</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>Or</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Sign in using {0}</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Welcome back!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirm Password</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>The server appears to be offline. Please try reconnecting or use offline mode.</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Server Address</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Discovered</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Scanning</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Rescan</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Browse Depot</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>No Results Found</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Reset Filter</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Uncategorized</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} was added to your library!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>{0} could not be added to your library!</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Check for Updates</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Games</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Storage Paths</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Add Path</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Media</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Storage Path</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Enable Script Debugging</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Logging Path</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Logging Level</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Settings saved!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>An unknown error occurred.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>You are on the latest version!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Update</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>Queued</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Installing</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Uninstalling</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Play Time</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Last Played</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Released On</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Installation Failed</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>The installation for {0} has failed. Retry download?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>None</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} minutes</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} hours</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Never</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Depot results could not be fetched</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Unexpected error fetching depot results</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Not found</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Sorry, there's nothing at this address.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>No Results</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>The depot is empty or you are unauthorized. Contact your adminstrator.</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>View in Library</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Remove from Library</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Add to Library</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Collection</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Tag</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.uk.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.uk.resx
@@ -1,0 +1,522 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>Лаунчер зламався</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>Переімпортувати бібліотеку</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>Перепідключитися до сервера</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>Переглянути бібліотеку</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>Ви померли.</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>Нове ім'я</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>Імпорт розпочато</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>Підключитися</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>Переглянути депо</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>Перевірити оновлення</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>Розмір завантаження</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>Встановити</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>Необхідне місце</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>Додатки</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>Місце встановлення</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>Посібник</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>Керувати збереженнями</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>Змінити</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>Переглянути файли</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>Перевірити файли</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>Видалити</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>Видалити</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>Запустити скрипти встановлення</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>Запустити скрипти видалення</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>Запустити скрипти зміни імені</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>Запустити скрипти зміни ключа</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>Повідомити про проблему</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>Встановити {0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>Змінити {0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>Конфлікти файлів</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>Замінити вибрані</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>Ви дійсно хочете видалити {0}? Всі локальні збереження будуть видалені.</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>Ви дійсно хочете видалити {0}?</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>Видалити гру</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Скасувати</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>Видалити гру з бібліотеки</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>Надіслати</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>Базова гра</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>Додатки для видалення</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>Не вдалося видалити гру</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>Проблему повідомлено!</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>Невідома помилка: проблема не повідомлена</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>Створено</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>Ви впевнені? Це замінить всі локальні збереження!</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>Ви дійсно хочете видалити це збереження?</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Завантажити</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>Збереження завантажено!</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>Збереження видалено!</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>Збереження завантажено!</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>Назва</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>Групувати за</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>Сортувати за</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>Двигун</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>Жанр</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Тег</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>Платформа</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>Розробники</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>Видавець</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>Гравці</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>Мінімум</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>Максимум</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>Встановлено</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Застосувати</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>Ви хочете зупинити цю гру?</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>Так</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>Запущено</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>Запускається</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>Зупиняється</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>Грати</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>Дії не знайдено!</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>Основну дію не знайдено!</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>Грати в {0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>Імпортування: {0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>Запуск імпорту...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>Увійти через {0}</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>Не вдалося обробити вхід</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>З'єднання втрачено, повторна спроба...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>З'єднання втрачено, повторна спроба ({0}/{1})...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>Сервер недоступний, увімкнення автономного режиму</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>З'єднання встановлено!</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>У процесі</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>Далі</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>Черга порожня</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>Завершено</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>Переглянути в бібліотеці</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0} додано до бібліотеки!</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>Не вдалося додати {0} до бібліотеки!</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>Адреса сервера</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>Ім'я користувача</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>Увійти</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>Зареєструватися</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>або</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>Ласкаво просимо назад!</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Підтвердити пароль</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>Схоже, сервер офлайн...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>Адреса сервера</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Офлайн</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>Знайдено</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>Сканування</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>Повторне сканування</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>Результатів не знайдено</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>Скинути фільтр</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>Без категорії</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Зберегти</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>Ігри</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>Шляхи зберігання</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>Додати шлях</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>Медіа</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>Шлях зберігання</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>Налагодження</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>Увімкнути налагодження скриптів</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>Шлях журналу</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>Рівень журналу</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>Налаштування збережено!</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>Сталася невідома помилка.</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>У вас найновіша версія!</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>Оновити</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>У черзі</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>Встановлення</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>Видалення</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>Час гри</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>Остання гра</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>Дата випуску</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>Встановлення не вдалося</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>Встановлення {0} не вдалося. Хочете спробувати завантажити ще раз?</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0} хв</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0} год</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>Ніколи</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>Не вдалося отримати результати депо</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>Неочікувана помилка при отриманні результатів депо</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>Не знайдено</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Вибачте, за цією адресою нічого немає.</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>Немає результатів</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>Депо порожнє або у вас немає доступу. Зверніться до адміністратора.</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>Видалити з бібліотеки</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>Додати до бібліотеки</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>Колекція</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>Тег</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>Запуск лаунчера v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>Завантаження налаштувань з файлу</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>Налаштування журналу...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>Реєстрація сервісів...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>Побудова додатку...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>Зображення не знайдено локально</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>Критична помилка</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>Запуск додатку...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>Закриття додатку...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>Помилку скопійовано до буфера обміну!</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>Знову онлайн!</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>Не вдалося перепідключитися!</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>Не вдається досягти сервера LANCommander. Вийти та спробувати ще раз?</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>Вийти</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>Залишитися офлайн</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>Змінити ім'я</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>Перейти в автономний режим</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>Зараз ви офлайн</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>Незабаром!</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>Друзі</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>Завантаження</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>Депо</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>Імпорт завершено</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>Імпорт не вдався</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>Пізніше</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>Оновлення лаунчера</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>Бібліотека</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>Локальний розмір</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Перемістити</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>Ім'я</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>Оригінальний розмір</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Resources/SharedResources.zh.resx
+++ b/LANCommander.Launcher/Resources/SharedResources.zh.resx
@@ -1,0 +1,540 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <data name="AppTitle" xml:space="preserve">
+    <value>LANCommander</value>
+  </data>
+  <data name="LauncherCrashed" xml:space="preserve">
+    <value>启动器崩溃了</value>
+  </data>
+  <data name="ReimportLibrary" xml:space="preserve">
+    <value>重新导入库</value>
+  </data>
+  <data name="ReconnectToServer" xml:space="preserve">
+    <value>重新连接到服务器</value>
+  </data>
+  <data name="ViewLibrary" xml:space="preserve">
+    <value>查看库</value>
+  </data>
+  <data name="YouDied" xml:space="preserve">
+    <value>你死了。</value>
+  </data>
+  <data name="NewName" xml:space="preserve">
+    <value>新名称</value>
+  </data>
+  <data name="ImportStarted" xml:space="preserve">
+    <value>导入已开始</value>
+  </data>
+  <data name="Connect" xml:space="preserve">
+    <value>连接</value>
+  </data>
+  <data name="BrowseDepot" xml:space="preserve">
+    <value>浏览仓库</value>
+  </data>
+  <data name="CheckForUpdates" xml:space="preserve">
+    <value>检查更新</value>
+  </data>
+  <data name="DownloadSize" xml:space="preserve">
+    <value>下载大小</value>
+  </data>
+  <data name="Install" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="SpaceRequired" xml:space="preserve">
+    <value>所需空间</value>
+  </data>
+  <data name="Addons" xml:space="preserve">
+    <value>附加组件</value>
+  </data>
+  <data name="InstallLocation" xml:space="preserve">
+    <value>安装位置</value>
+  </data>
+  <data name="Manual" xml:space="preserve">
+    <value>手册</value>
+  </data>
+  <data name="ManageSaves" xml:space="preserve">
+    <value>管理存档</value>
+  </data>
+  <data name="Modify" xml:space="preserve">
+    <value>修改</value>
+  </data>
+  <data name="BrowseFiles" xml:space="preserve">
+    <value>浏览文件</value>
+  </data>
+  <data name="ValidateFiles" xml:space="preserve">
+    <value>验证文件</value>
+  </data>
+  <data name="Remove" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="Uninstall" xml:space="preserve">
+    <value>卸载</value>
+  </data>
+  <data name="RunInstallScripts" xml:space="preserve">
+    <value>运行安装脚本</value>
+  </data>
+  <data name="RunUninstallScripts" xml:space="preserve">
+    <value>运行卸载脚本</value>
+  </data>
+  <data name="RunNameChangeScripts" xml:space="preserve">
+    <value>运行名称更改脚本</value>
+  </data>
+  <data name="RunKeyChangeScripts" xml:space="preserve">
+    <value>运行密钥更改脚本</value>
+  </data>
+  <data name="ReportIssue" xml:space="preserve">
+    <value>报告问题</value>
+  </data>
+  <data name="InstallGame" xml:space="preserve">
+    <value>安装{0}</value>
+  </data>
+  <data name="ModifyGame" xml:space="preserve">
+    <value>修改{0}</value>
+  </data>
+  <data name="FileConflicts" xml:space="preserve">
+    <value>文件冲突</value>
+  </data>
+  <data name="ReplaceSelected" xml:space="preserve">
+    <value>替换选中的</value>
+  </data>
+  <data name="UninstallGameMessageWithSaves" xml:space="preserve">
+    <value>您确定要卸载{0}吗？所有本地存档将被删除。</value>
+  </data>
+  <data name="UninstallGameMessageWithoutSaves" xml:space="preserve">
+    <value>您确定要卸载{0}吗？</value>
+  </data>
+  <data name="UninstallGame" xml:space="preserve">
+    <value>卸载游戏</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="RemoveGameFromLibrary" xml:space="preserve">
+    <value>从库中删除游戏</value>
+  </data>
+  <data name="Submit" xml:space="preserve">
+    <value>提交</value>
+  </data>
+  <data name="BaseGame" xml:space="preserve">
+    <value>基础游戏</value>
+  </data>
+  <data name="AddonsToRemove" xml:space="preserve">
+    <value>要删除的附加组件</value>
+  </data>
+  <data name="CouldNotRemoveGame" xml:space="preserve">
+    <value>无法删除游戏</value>
+  </data>
+  <data name="IssueReported" xml:space="preserve">
+    <value>问题已报告！</value>
+  </data>
+  <data name="UnknownErrorIssueNotReported" xml:space="preserve">
+    <value>未知错误：问题未报告</value>
+  </data>
+  <data name="CreatedOn" xml:space="preserve">
+    <value>创建于</value>
+  </data>
+  <data name="AreYouSureReplaceLocalSaves" xml:space="preserve">
+    <value>您确定吗？这将替换所有本地存档！</value>
+  </data>
+  <data name="AreYouSureDeleteSave" xml:space="preserve">
+    <value>您确定要删除此存档吗？</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>上传</value>
+  </data>
+  <data name="SaveDownloaded" xml:space="preserve">
+    <value>存档已下载！</value>
+  </data>
+  <data name="SaveDeleted" xml:space="preserve">
+    <value>存档已删除！</value>
+  </data>
+  <data name="SaveUploaded" xml:space="preserve">
+    <value>存档已上传！</value>
+  </data>
+  <data name="Title" xml:space="preserve">
+    <value>标题</value>
+  </data>
+  <data name="GroupBy" xml:space="preserve">
+    <value>分组方式</value>
+  </data>
+  <data name="SortBy" xml:space="preserve">
+    <value>排序方式</value>
+  </data>
+  <data name="Engine" xml:space="preserve">
+    <value>引擎</value>
+  </data>
+  <data name="Genre" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>标签</value>
+  </data>
+  <data name="Platform" xml:space="preserve">
+    <value>平台</value>
+  </data>
+  <data name="Developers" xml:space="preserve">
+    <value>开发者</value>
+  </data>
+  <data name="Publishers" xml:space="preserve">
+    <value>发行商</value>
+  </data>
+  <data name="Players" xml:space="preserve">
+    <value>玩家数</value>
+  </data>
+  <data name="Minimum" xml:space="preserve">
+    <value>最小</value>
+  </data>
+  <data name="Maximum" xml:space="preserve">
+    <value>最大</value>
+  </data>
+  <data name="Installed" xml:space="preserve">
+    <value>已安装</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>应用</value>
+  </data>
+  <data name="DoYouWantToStopGame" xml:space="preserve">
+    <value>您要停止此游戏吗？</value>
+  </data>
+  <data name="Yes" xml:space="preserve">
+    <value>是</value>
+  </data>
+  <data name="Running" xml:space="preserve">
+    <value>运行中</value>
+  </data>
+  <data name="Starting" xml:space="preserve">
+    <value>启动中</value>
+  </data>
+  <data name="Stopping" xml:space="preserve">
+    <value>停止中</value>
+  </data>
+  <data name="Play" xml:space="preserve">
+    <value>游戏</value>
+  </data>
+  <data name="NoActionsFound" xml:space="preserve">
+    <value>未找到操作！</value>
+  </data>
+  <data name="NoPrimaryActionFound" xml:space="preserve">
+    <value>未找到主要操作！</value>
+  </data>
+  <data name="PlayGame" xml:space="preserve">
+    <value>游戏{0}</value>
+  </data>
+  <data name="Importing" xml:space="preserve">
+    <value>导入中：{0}</value>
+  </data>
+  <data name="StartingImport" xml:space="preserve">
+    <value>开始导入...</value>
+  </data>
+  <data name="SignInUsingProvider" xml:space="preserve">
+    <value>使用{0}登录</value>
+  </data>
+  <data name="CouldNotProcessLogin" xml:space="preserve">
+    <value>无法处理登录</value>
+  </data>
+  <data name="LostConnectionRetrying" xml:space="preserve">
+    <value>连接丢失，重试中...</value>
+  </data>
+  <data name="LostConnectionRetryingWithCount" xml:space="preserve">
+    <value>连接丢失，重试中（{0}/{1}）...</value>
+  </data>
+  <data name="ServerUnavailableEnablingOfflineMode" xml:space="preserve">
+    <value>服务器不可用，启用离线模式</value>
+  </data>
+  <data name="ConnectionEstablished" xml:space="preserve">
+    <value>连接已建立！</value>
+  </data>
+  <data name="InProgress" xml:space="preserve">
+    <value>进行中</value>
+  </data>
+  <data name="UpNext" xml:space="preserve">
+    <value>下一个</value>
+  </data>
+  <data name="TheQueueIsEmpty" xml:space="preserve">
+    <value>队列为空</value>
+  </data>
+  <data name="Completed" xml:space="preserve">
+    <value>已完成</value>
+  </data>
+  <data name="ViewInLibrary" xml:space="preserve">
+    <value>在库中查看</value>
+  </data>
+  <data name="GameAddedToLibrary" xml:space="preserve">
+    <value>{0}已添加到您的库！</value>
+  </data>
+  <data name="GameCouldNotBeAddedToLibrary" xml:space="preserve">
+    <value>无法将{0}添加到您的库！</value>
+  </data>
+  <data name="ServerAddress" xml:space="preserve">
+    <value>服务器地址</value>
+  </data>
+  <data name="Username" xml:space="preserve">
+    <value>用户名</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>密码</value>
+  </data>
+  <data name="Login" xml:space="preserve">
+    <value>登录</value>
+  </data>
+  <data name="Register" xml:space="preserve">
+    <value>注册</value>
+  </data>
+  <data name="Or" xml:space="preserve">
+    <value>或</value>
+  </data>
+  <data name="WelcomeBack" xml:space="preserve">
+    <value>欢迎回来！</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>确认密码</value>
+  </data>
+  <data name="ServerOfflineMessage" xml:space="preserve">
+    <value>服务器似乎离线...</value>
+  </data>
+  <data name="ServerAddressPlaceholder" xml:space="preserve">
+    <value>服务器地址</value>
+  </data>
+  <data name="Offline" xml:space="preserve">
+    <value>离线</value>
+  </data>
+  <data name="Discovered" xml:space="preserve">
+    <value>已发现</value>
+  </data>
+  <data name="Scanning" xml:space="preserve">
+    <value>扫描中</value>
+  </data>
+  <data name="Rescan" xml:space="preserve">
+    <value>重新扫描</value>
+  </data>
+  <data name="NoResultsFound" xml:space="preserve">
+    <value>未找到结果</value>
+  </data>
+  <data name="ResetFilter" xml:space="preserve">
+    <value>重置过滤器</value>
+  </data>
+  <data name="Uncategorized" xml:space="preserve">
+    <value>未分类</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>保存</value>
+  </data>
+  <data name="Games" xml:space="preserve">
+    <value>游戏</value>
+  </data>
+  <data name="StoragePaths" xml:space="preserve">
+    <value>存储路径</value>
+  </data>
+  <data name="AddPath" xml:space="preserve">
+    <value>添加路径</value>
+  </data>
+  <data name="Media" xml:space="preserve">
+    <value>媒体</value>
+  </data>
+  <data name="StoragePath" xml:space="preserve">
+    <value>存储路径</value>
+  </data>
+  <data name="Debug" xml:space="preserve">
+    <value>调试</value>
+  </data>
+  <data name="EnableScriptDebugging" xml:space="preserve">
+    <value>启用脚本调试</value>
+  </data>
+  <data name="LoggingPath" xml:space="preserve">
+    <value>日志路径</value>
+  </data>
+  <data name="LoggingLevel" xml:space="preserve">
+    <value>日志级别</value>
+  </data>
+  <data name="SettingsSaved" xml:space="preserve">
+    <value>设置已保存！</value>
+  </data>
+  <data name="AnUnknownErrorOccurred" xml:space="preserve">
+    <value>发生未知错误。</value>
+  </data>
+  <data name="YouAreOnLatestVersion" xml:space="preserve">
+    <value>您使用的是最新版本！</value>
+  </data>
+  <data name="Update" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="Queued" xml:space="preserve">
+    <value>排队中</value>
+  </data>
+  <data name="Installing" xml:space="preserve">
+    <value>安装中</value>
+  </data>
+  <data name="Uninstalling" xml:space="preserve">
+    <value>卸载中</value>
+  </data>
+  <data name="PlayTime" xml:space="preserve">
+    <value>游戏时间</value>
+  </data>
+  <data name="LastPlayed" xml:space="preserve">
+    <value>最后游戏</value>
+  </data>
+  <data name="ReleasedOn" xml:space="preserve">
+    <value>发布日期</value>
+  </data>
+  <data name="InstallationFailed" xml:space="preserve">
+    <value>安装失败</value>
+  </data>
+  <data name="InstallationFailedMessage" xml:space="preserve">
+    <value>{0}的安装失败。重试下载？</value>
+  </data>
+  <data name="None" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="PlayTimeMinutes" xml:space="preserve">
+    <value>{0}分钟</value>
+  </data>
+  <data name="PlayTimeHours" xml:space="preserve">
+    <value>{0}小时</value>
+  </data>
+  <data name="Never" xml:space="preserve">
+    <value>从未</value>
+  </data>
+  <data name="DepotResultsCouldNotBeFetched" xml:space="preserve">
+    <value>无法获取仓库结果</value>
+  </data>
+  <data name="UnexpectedErrorFetchingDepotResults" xml:space="preserve">
+    <value>获取仓库结果时发生意外错误</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>未找到</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>抱歉，此地址没有任何内容。</value>
+  </data>
+  <data name="NoResults" xml:space="preserve">
+    <value>无结果</value>
+  </data>
+  <data name="DepotEmptyOrUnauthorized" xml:space="preserve">
+    <value>仓库为空或您未授权。请联系您的管理员。</value>
+  </data>
+  <data name="RemoveFromLibrary" xml:space="preserve">
+    <value>从库中删除</value>
+  </data>
+  <data name="AddToLibrary" xml:space="preserve">
+    <value>添加到库</value>
+  </data>
+  <data name="Collection" xml:space="preserve">
+    <value>收藏</value>
+  </data>
+  <data name="Tag" xml:space="preserve">
+    <value>标签</value>
+  </data>
+  <data name="StartingUpLauncher" xml:space="preserve">
+    <value>启动启动器v{0}...</value>
+  </data>
+  <data name="LoadingSettingsFromFile" xml:space="preserve">
+    <value>从文件加载设置</value>
+  </data>
+  <data name="ConfiguringLogging" xml:space="preserve">
+    <value>配置日志记录...</value>
+  </data>
+  <data name="RegisteringServices" xml:space="preserve">
+    <value>注册服务...</value>
+  </data>
+  <data name="BuildingApplication" xml:space="preserve">
+    <value>构建应用程序...</value>
+  </data>
+  <data name="ImageNotFoundLocally" xml:space="preserve">
+    <value>本地未找到图像</value>
+  </data>
+  <data name="FatalException" xml:space="preserve">
+    <value>致命异常</value>
+  </data>
+  <data name="StartingApplication" xml:space="preserve">
+    <value>启动应用程序...</value>
+  </data>
+  <data name="ClosingApplication" xml:space="preserve">
+    <value>关闭应用程序...</value>
+  </data>
+  <data name="ErrorCopiedToClipboard" xml:space="preserve">
+    <value>错误已复制到剪贴板！</value>
+  </data>
+  <data name="BackOnline" xml:space="preserve">
+    <value>重新上线！</value>
+  </data>
+  <data name="CouldNotReconnect" xml:space="preserve">
+    <value>无法重新连接！</value>
+  </data>
+  <data name="CouldNotReconnectMessage" xml:space="preserve">
+    <value>无法到达LANCommander服务器。您要注销并重试吗？</value>
+  </data>
+  <data name="Logout" xml:space="preserve">
+    <value>注销</value>
+  </data>
+  <data name="StayOffline" xml:space="preserve">
+    <value>保持离线</value>
+  </data>
+  <data name="ChangeName" xml:space="preserve">
+    <value>更改名称</value>
+  </data>
+  <data name="SwitchToOfflineMode" xml:space="preserve">
+    <value>切换到离线模式</value>
+  </data>
+  <data name="YouAreCurrentlyOffline" xml:space="preserve">
+    <value>您当前离线</value>
+  </data>
+  <data name="ComingSoon" xml:space="preserve">
+    <value>即将推出！</value>
+  </data>
+  <data name="Friends" xml:space="preserve">
+    <value>好友</value>
+  </data>
+  <data name="Downloads" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="Depot" xml:space="preserve">
+    <value>仓库</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>设置</value>
+  </data>
+  <data name="SignIn" xml:space="preserve">
+    <value>登入</value>
+  </data>
+  <data name="SourceGame" xml:space="preserve">
+    <value>源码游戏</value>
+  </data>
+  <data name="UninstallGameMessage" xml:space="preserve">
+    <value>您想卸载 {0} 吗</value>
+  </data>
+  <data name="UpdateAvailableMessage" xml:space="preserve">
+    <value>v{0} 有可用的更新。要下载并安装吗？</value>
+  </data>
+  <data name="UpdateNow" xml:space="preserve">
+    <value>立即更新</value>
+  </data>
+  <data name="ImportComplete" xml:space="preserve">
+    <value>导入完成</value>
+  </data>
+  <data name="ImportFailed" xml:space="preserve">
+    <value>导入失败</value>
+  </data>
+  <data name="Later" xml:space="preserve">
+    <value>稍后</value>
+  </data>
+  <data name="LauncherUpdate" xml:space="preserve">
+    <value>启动器更新</value>
+  </data>
+  <data name="Library" xml:space="preserve">
+    <value>库</value>
+  </data>
+  <data name="LocalSize" xml:space="preserve">
+    <value>本地大小</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>移动</value>
+  </data>
+  <data name="Name" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="OriginalSize" xml:space="preserve">
+    <value>原始大小</value>
+  </data>
+</root> 

--- a/LANCommander.Launcher/Services/LocalizationService.cs
+++ b/LANCommander.Launcher/Services/LocalizationService.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using System.Resources;
+using LANCommander.Launcher.Models;
+
+namespace LANCommander.Launcher.Services
+{
+    public class LocalizationService
+    {
+        private readonly Settings _settings;
+        private readonly ResourceManager _resourceManager;
+
+        public LocalizationService()
+        {
+            _settings = SettingService.GetSettings();
+            _resourceManager = new ResourceManager("LANCommander.Launcher.Resources.SharedResources", typeof(LocalizationService).Assembly);
+            
+            var culture = new CultureInfo(_settings.Culture);
+            
+            Thread.CurrentThread.CurrentCulture = culture;
+            Thread.CurrentThread.CurrentUICulture = culture;
+        }
+
+        public string GetString(string key)
+        {
+            return _resourceManager.GetString(key) ?? key;
+        }
+
+        public string GetString(string key, params object[] args)
+        {
+            var format = _resourceManager.GetString(key) ?? key;
+            return string.Format(CultureInfo.CurrentCulture, format, args);
+        }
+
+        public string GetString(string key, CultureInfo culture)
+        {
+            return _resourceManager.GetString(key, culture) ?? key;
+        }
+
+        public string GetString(string key, CultureInfo culture, params object[] args)
+        {
+            var format = _resourceManager.GetString(key, culture) ?? key;
+            return string.Format(culture, format, args);
+        }
+    }
+} 

--- a/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/LoginForm.razor
@@ -6,10 +6,11 @@
 @inject IMessageService MessageService
 @inject ILogger<LoginForm> Logger
 @inject ImportManagerService ImportManagerService
+@inject LocalizationService LocalizationService
 
 <PageHeader OnBack="OnBack">
     <TitleTemplate>
-        Sign In
+        @LocalizationService.GetString("SignIn")
     </TitleTemplate>
 </PageHeader>
 <Form Model="@Model" Loading="@Loading" Layout="FormLayout.Vertical" OnFinish="OnFinish">
@@ -19,29 +20,29 @@
         <Alert Message="@item" Type="AlertType.Error" ShowIcon="true" Style="margin-bottom: 8px;" />
     }
 
-    <FormItem Label="Server Address">
+    <FormItem Label="@LocalizationService.GetString("ServerAddress")">
         <Input Value="ServerAddress" Disabled />
     </FormItem>
-    <FormItem Label="Username">
+    <FormItem Label="@LocalizationService.GetString("Username")">
         <Input @bind-Value="@context.UserName" AutoFocus />
     </FormItem>
-    <FormItem Label="Password">
+    <FormItem Label="@LocalizationService.GetString("Password")">
         <InputPassword @bind-Value="@context.Password"/>
     </FormItem>
     <FormItem>
         <Button Type="ButtonType.Primary" HtmlType="submit">
-            Login
+            @LocalizationService.GetString("Login")
         </Button>
 
         <Button Type="ButtonType.Text" OnClick="OnRegister">
-            Register
+            @LocalizationService.GetString("Register")
         </Button>
     </FormItem>
 </Form>
 
 @if (AuthenticationProviders.Any())
 {
-    <Divider Orientation="DividerOrientation.Center" Text="Or" Style="margin-bottom: 16px" />
+    <Divider Orientation="DividerOrientation.Center" Text="@LocalizationService.GetString("Or")" Style="margin-bottom: 16px" />
 
     <div class="authentication-provider-container">
         <div class="authentication-provider-button-group">
@@ -57,7 +58,7 @@
                         {
                             <BootstrapIcon Type="@authenticationProvider.Icon"/>
                         }
-                        Sign in using @authenticationProvider.Name
+                        @LocalizationService.GetString("SignInUsingProvider", authenticationProvider.Name)
                     </Button>
                 </div>
             }
@@ -133,7 +134,7 @@
 
             NavigationManager.NavigateTo("/");
             
-            MessageService.Success("Welcome back!");
+            MessageService.Success(LocalizationService.GetString("WelcomeBack"));
         }
         catch (AuthFailedException ex)
         {

--- a/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/RegistrationForm.razor
@@ -6,10 +6,11 @@
 @inject IMessageService MessageService
 @inject ILogger<RegistrationForm> Logger
 @inject ImportManagerService ImportManagerService
+@inject LocalizationService LocalizationService
 
 <PageHeader OnBack="OnBack">
     <TitleTemplate>
-        Register
+        @LocalizationService.GetString("Register")
     </TitleTemplate>
 </PageHeader>
 <Form Model="@Model" Loading="@Loading" Layout="FormLayout.Vertical" OnFinish="OnFinish">
@@ -19,21 +20,21 @@
         <Alert Message="@item" Type="AlertType.Error" ShowIcon="true" Style="margin-bottom: 8px;" />
     }
 
-    <FormItem Label="Server Address">
+    <FormItem Label="@LocalizationService.GetString("ServerAddress")">
         <Input Value="ServerAddress" Disabled />
     </FormItem>
-    <FormItem Label="Username">
+    <FormItem Label="@LocalizationService.GetString("Username")">
         <Input @bind-Value="@context.UserName" AutoFocus />
     </FormItem>
-    <FormItem Label="Password">
+    <FormItem Label="@LocalizationService.GetString("Password")">
         <InputPassword @bind-Value="@context.Password"/>
     </FormItem>
-    <FormItem Label="Confirm Password">
+    <FormItem Label="@LocalizationService.GetString("ConfirmPassword")">
         <InputPassword @bind-Value="@context.PasswordConfirmation" />
     </FormItem>
     <FormItem>
         <Button Type="ButtonType.Primary" HtmlType="submit">
-            Register
+            @LocalizationService.GetString("Register")
         </Button>
     </FormItem>
 </Form>

--- a/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Authenticate/Components/ServerSelector.razor
@@ -4,10 +4,11 @@
 @inject NavigationManager NavigationManager
 @inject SDK.Client Client
 @inject AuthenticationService AuthenticationService
+@inject LocalizationService LocalizationService
 
 <PageHeader>
     <TitleTemplate>
-        Connect
+        @LocalizationService.GetString("Connect")
     </TitleTemplate>
 </PageHeader>
 
@@ -15,23 +16,23 @@
 
     @if (OfflineModeAvailable)
     {
-        <Alert Message="The server appears to be offline. Please try reconnecting or use offline mode." Type="AlertType.Warning" ShowIcon="true" Style="margin-bottom: 16px;" />
+        <Alert Message="@LocalizationService.GetString("ServerOfflineMessage")" Type="AlertType.Warning" ShowIcon="true" Style="margin-bottom: 16px;" />
     }
 
     <FormItem>
         <Flex Gap="FlexGap.Small">
-            <Input @bind-Value="ServerAddress" Placeholder="Server Address" AutoFocus Disabled="Connecting" />
-            <Button Type="ButtonType.Primary" HtmlType="submit" Disabled="Connecting" Loading="Connecting">Connect</Button>
+            <Input @bind-Value="ServerAddress" Placeholder="@LocalizationService.GetString("ServerAddressPlaceholder")" AutoFocus Disabled="Connecting" />
+            <Button Type="ButtonType.Primary" HtmlType="submit" Disabled="Connecting" Loading="Connecting">@LocalizationService.GetString("Connect")</Button>
 
             @if (OfflineModeAvailable)
             {
-                <Button OnClick="() => OfflineMode()">Offline</Button>
+                <Button OnClick="() => OfflineMode()">@LocalizationService.GetString("Offline")</Button>
             }
         </Flex>
     </FormItem>
 </Form>
 
-<Divider Text="Discovered" Orientation="DividerOrientation.Center" />
+<Divider Text="@LocalizationService.GetString("Discovered")" Orientation="DividerOrientation.Center" />
 
 <AntList DataSource="DiscoveredServers">
     <ChildContent>
@@ -47,17 +48,17 @@
                 <Dropdown Trigger="@(new [] { Trigger.Hover })">
                     <Overlay>
                         <Menu>
-                            <MenuItem Key="Cancel" OnClick="CancelBeacon">Cancel</MenuItem>
+                            <MenuItem Key="Cancel" OnClick="CancelBeacon">@LocalizationService.GetString("Cancel")</MenuItem>
                         </Menu>
                     </Overlay>
                     <ChildContent>
-                        <Button Type="ButtonType.Primary" Loading="true" Disabled>Scanning</Button>
+                        <Button Type="ButtonType.Primary" Loading="true" Disabled>@LocalizationService.GetString("Scanning")</Button>
                     </ChildContent>
                 </Dropdown>
             }
             else
             {
-                <Button Type="ButtonType.Primary" OnClick="() => ActivateBeacon()">Rescan</Button>
+                <Button Type="ButtonType.Primary" OnClick="() => ActivateBeacon()">@LocalizationService.GetString("Rescan")</Button>
             }
         </Flex>
     </LoadMore>

--- a/LANCommander.Launcher/UI/Components/AuthenticationProviderDialog.razor
+++ b/LANCommander.Launcher/UI/Components/AuthenticationProviderDialog.razor
@@ -5,6 +5,7 @@
 @inject IJSRuntime JSRuntime
 @inject IMessageService MessageService
 @inject ILogger<AuthenticationProviderDialog> Logger
+@inject LocalizationService LocalizationService
 
 @code {
     [Parameter] public EventCallback<AuthToken> OnTokenReceived { get; set; }
@@ -20,7 +21,7 @@
         AuthenticationProviderLoginUrl = Client.GetAuthenticationProviderLoginUrl(authenticationProvider.Slug);
 
         Window = new PhotinoWindow()
-            .SetTitle($"Sign in using {authenticationProvider.Name}")
+            .SetTitle(LocalizationService.GetString("SignInUsingProvider", authenticationProvider.Name))
             .Load(AuthenticationProviderLoginUrl)
             .SetContextMenuEnabled(false);
 
@@ -43,7 +44,7 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Could not process login");
-            MessageService.Error("Could not process login");
+            MessageService.Error(LocalizationService.GetString("CouldNotProcessLogin"));
         }
         finally
         {

--- a/LANCommander.Launcher/UI/Components/ChangeAliasDialog.razor
+++ b/LANCommander.Launcher/UI/Components/ChangeAliasDialog.razor
@@ -1,7 +1,8 @@
 ﻿@inherits FeedbackComponent<string, string>
+@inject LocalizationService LocalizationService
 
 <Form Model="Model" OnFinish="Save">
-    <FormItem Label="New Name">
+    <FormItem Label="@LocalizationService.GetString("NewName")">
         <Input @bind-Value="@context.NewAlias" />
     </FormItem>
 </Form>

--- a/LANCommander.Launcher/UI/Components/DownloadQueue.razor
+++ b/LANCommander.Launcher/UI/Components/DownloadQueue.razor
@@ -1,12 +1,13 @@
 ﻿@using LANCommander.Launcher.Models
 @inject InstallService InstallService
 @inject NavigationManager NavigationManager
+@inject LocalizationService LocalizationService
 
 <Drawer Placement="DrawerPlacement.Bottom" Class="download-queue" @bind-Visible="@Visible" OnClose="Hide">
 
     @if (InstallService.Queue.Any(qi => qi.State))
     {
-        <h2>In Progress</h2>
+        <h2>@LocalizationService.GetString("InProgress")</h2>
         @foreach (var queueItem in InstallService.Queue.Where(qi => qi.State))
         {
             <div class="queue-item">
@@ -23,7 +24,7 @@
         }
     }
 
-    <h2>Up Next</h2>
+    <h2>@LocalizationService.GetString("UpNext")</h2>
     @foreach (var queueItem in InstallService.Queue.Where(qi => !qi.State && qi.Status == SDK.Enums.InstallStatus.Queued))
     {
         <div class="queue-item">
@@ -41,12 +42,12 @@
 
     @if (!InstallService.Queue.Any(qi => qi.Status == SDK.Enums.InstallStatus.Queued))
     {
-        <Empty Simple Description="@("The queue is empty")" />
+        <Empty Simple Description="@LocalizationService.GetString("TheQueueIsEmpty")" />
     }
 
     @if (InstallService.Queue.Any(qi => !qi.State && qi.Status != SDK.Enums.InstallStatus.Queued && qi.Status != SDK.Enums.InstallStatus.Failed && qi.Status != SDK.Enums.InstallStatus.Canceled))
     {
-        <h2>Completed</h2>
+        <h2>@LocalizationService.GetString("Completed")</h2>
         @foreach (var queueItem in InstallService.Queue.Where(qi => !qi.State))
         {
             <div class="queue-item">
@@ -61,7 +62,7 @@
                     <PlayButton LibraryItemId="@queueItem.Id">
                         <MenuExtra>
                             <MenuItem OnClick="() => ViewInLibrary(queueItem)">
-                                View in Library
+                                @LocalizationService.GetString("ViewInLibrary")
                             </MenuItem>
                         </MenuExtra>
                     </PlayButton>

--- a/LANCommander.Launcher/UI/Components/Footer.razor
+++ b/LANCommander.Launcher/UI/Components/Footer.razor
@@ -4,12 +4,13 @@
 @inject InstallService InstallService
 @inject GameService GameService
 @inject NavigationManager NavigationManager
+@inject LocalizationService LocalizationService
 
 <Flex Justify="FlexJustify.Center" Align="FlexAlign.Center" Gap="FlexGap.Small" Class="footer">
     <div style="flex: 1;">
         @if (NavigationManager.Uri.Contains("/Depot"))
         {
-            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Hdd" OnClick="@(() => NavigationManager.NavigateTo("/"))">Library</Button>
+            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Hdd" OnClick="@(() => NavigationManager.NavigateTo("/"))">@LocalizationService.GetString("Library")</Button>
         }
         else
         {
@@ -17,11 +18,11 @@
             {
                 <ConnectionStateView>
                     <Online>
-                        <Button Type="@ButtonType.Text" Icon="@IconType.Outline.AppstoreAdd" OnClick="@(() => NavigationManager.NavigateTo("/Depot"))">Depot</Button>
+                        <Button Type="@ButtonType.Text" Icon="@IconType.Outline.AppstoreAdd" OnClick="@(() => NavigationManager.NavigateTo("/Depot"))">@LocalizationService.GetString("Depot")</Button>
                     </Online>
                     <Offline>
-                        <Tooltip Title="You are currently offline" Placement="Placement.TopLeft">
-                            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.AppstoreAdd" Disabled>Depot</Button>
+                        <Tooltip Title="@LocalizationService.GetString("YouAreCurrentlyOffline")" Placement="Placement.TopLeft">
+                            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.AppstoreAdd" Disabled>@LocalizationService.GetString("Depot")</Button>
                         </Tooltip>
                     </Offline>
                 </ConnectionStateView>
@@ -39,19 +40,19 @@
             }
             else
             {
-                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" OnClick="() => ShowDownloadQueue()">Downloads</Button>
+                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" OnClick="() => ShowDownloadQueue()">@LocalizationService.GetString("Downloads")</Button>
             }
         </Online>
         <Offline>
-            <Tooltip Title="You are currently offline" Placement="Placement.TopLeft">
-                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" Disabled>Downloads</Button>
+            <Tooltip Title="@LocalizationService.GetString("YouAreCurrentlyOffline")" Placement="Placement.TopLeft">
+                <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" Disabled>@LocalizationService.GetString("Downloads")</Button>
             </Tooltip>
         </Offline>
     </ConnectionStateView>
 
     <div style="flex: 1; text-align:  right;">
-        <Tooltip Title="Coming soon!" Placement="Placement.TopRight">
-            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Team" Disabled>Friends</Button>
+        <Tooltip Title="@LocalizationService.GetString("ComingSoon")" Placement="Placement.TopRight">
+            <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Team" Disabled>@LocalizationService.GetString("Friends")</Button>
         </Tooltip>
     </div>
 </Flex>

--- a/LANCommander.Launcher/UI/Components/ImportHandler.razor
+++ b/LANCommander.Launcher/UI/Components/ImportHandler.razor
@@ -4,6 +4,7 @@
 @inject ImportService ImportService
 @inject IMessageService MessageService
 @inject ILogger<ImportHandler> Logger
+@inject LocalizationService LocalizationService
 
 @code 
 {
@@ -57,7 +58,7 @@
             await NotifyProgress(ImportProgressState.Importing);
 
             await InvokeAsync(StateHasChanged);
-            MessageService.Info("Import Started", 2.5);
+            MessageService.Info(LocalizationService.GetString("ImportStarted"), 2.5);
 
             Logger?.LogInformation("Starting import");
             await ImportService.ImportLibraryAsync(); // Call directly instead of using JS
@@ -85,7 +86,7 @@
         ImportStatusTotal = 0;
 
         await NotifyProgress(ImportProgressState.Imported);
-        MessageService.Success("Import Complete", 3);
+        MessageService.Success(LocalizationService.GetString("ImportComplete"), 3);
     }
 
     private async Task OnImportFailedHandler(Exception ex)
@@ -95,7 +96,7 @@
         ImportStatusTotal = 0;
 
         await NotifyProgress(ImportProgressState.Failed);
-        MessageService.Error("Import Failed", 3);
+        MessageService.Error(LocalizationService.GetString("ImportFailed"), 3);
     }
 
     private async Task OnImportUpdatedHandler(ImportStatusUpdate status)

--- a/LANCommander.Launcher/UI/Components/ImportProgressDisplay.razor
+++ b/LANCommander.Launcher/UI/Components/ImportProgressDisplay.razor
@@ -1,5 +1,6 @@
 @using LANCommander.Launcher.Models
 @inject ImportService ImportService
+@inject LocalizationService LocalizationService
 
 <div class="import-progress">
     <div class="import-progress-container">
@@ -8,11 +9,11 @@
                 <div class="import-progress-status">
                     @if (Total > 0)
                     {
-                        <Text>Importing: @(CurrentItem?.Name ?? "")</Text>
+                        <Text>@LocalizationService.GetString("Importing", CurrentItem?.Name ?? "")</Text>
                     }
                     else
                     {
-                        <Text>Starting import...</Text>
+                        <Text>@LocalizationService.GetString("StartingImport")</Text>
                     }
                 </div>
                 <div class="import-progress-progress-bar">

--- a/LANCommander.Launcher/UI/Components/InstallDialog.razor
+++ b/LANCommander.Launcher/UI/Components/InstallDialog.razor
@@ -4,28 +4,29 @@
 @inherits FeedbackComponent<Models.ListItem, string>
 @inject InstallService InstallService
 @inject SDK.Client Client
+@inject LocalizationService LocalizationService
 
 <div style="padding: 16px;">
     <Row Gutter="16">
         <Col Span="12">
-            <Statistic Title="Download Size" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()" Style="text-align: center;"/>
+            <Statistic Title="@LocalizationService.GetString("DownloadSize")" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()" Style="text-align: center;"/>
         </Col>
         <Col Span="12">
-            <Statistic Title="Space Required" Value="@ByteSizeLib.ByteSize.FromBytes(GetSpaceRequired()).ToString()" Style="text-align: center;"/>
+            <Statistic Title="@LocalizationService.GetString("SpaceRequired")" Value="@ByteSizeLib.ByteSize.FromBytes(GetSpaceRequired()).ToString()" Style="text-align: center;"/>
         </Col>
     </Row>
 
 
     @if (Addons.Any())
     {
-        <Divider Text="Addons" />
+        <Divider Text="@LocalizationService.GetString("Addons")" />
 
         <CheckboxButtonGroup @bind-Selected="SelectedAddons" DataSource="Addons" KeySelector="a => a.Id" LabelSelector="a => a.Title" Direction="SpaceDirection.Vertical" />
     }
 
     @if (Settings.Games.InstallDirectories.Length > 1)
     {
-        <Divider Text="Install Location" />
+        <Divider Text="@LocalizationService.GetString("InstallLocation")" />
         <RadioGroup @bind-Value="SelectedDirectory" ButtonStyle="RadioButtonStyle.Solid" Size="InputSize.Large" Class="install-dialog-directory-selector radio-group-vertical radio-group-block">
             @foreach (var directory in Settings.Games.InstallDirectories)
             {
@@ -46,12 +47,12 @@
 
 
 <Flex Gap="FlexGap.Middle" Style="padding: 16px; padding-top: 0px" Justify="FlexJustify.FlexEnd">
-    @if (GetOperation() != InstallOperation.None)
+    @if (GetOperation() != "None")
     {
-        <Button Type="ButtonType.Primary" OnClick="Install">@GetOperation()</Button>
+        <Button Type="ButtonType.Primary" OnClick="Install">@LocalizationService.GetString(GetOperation())</Button>
     }
 
-    <Button OnClick="() => Close()">Close</Button>
+    <Button OnClick="() => Close()">@LocalizationService.GetString("Close")</Button>
 </Flex>
 
 @code {
@@ -65,13 +66,7 @@
     List<SDK.Models.Game> Addons = new();
     IEnumerable<SDK.Models.Game> SelectedAddons = new List<SDK.Models.Game>();
 
-    enum InstallOperation
-    {
-        None,
-        Install,
-        Move,
-        Modify,
-    }
+
 
     protected override async Task OnInitializedAsync()
     {
@@ -104,18 +99,18 @@
         await CloseFeedbackAsync();
     }
 
-    InstallOperation GetOperation()
+    string GetOperation()
     {
         if (!Game.Installed)
-            return InstallOperation.Install;
+            return "Install";
 
         if (Game.DependentGames.Any(g => g.Installed ^ SelectedAddons.Any(a => a.Id == g.Id)))
-            return InstallOperation.Modify;
+            return "Modify";
 
         if (!Game.InstallDirectory.StartsWith(SelectedDirectory))
-            return InstallOperation.Move;
+            return "Move";
 
-        return InstallOperation.None;
+        return string.Empty;
     }
 
     long GetDownloadSize()

--- a/LANCommander.Launcher/UI/Components/KeepAliveContainer.razor
+++ b/LANCommander.Launcher/UI/Components/KeepAliveContainer.razor
@@ -1,6 +1,7 @@
 @implements IDisposable
 @inject KeepAliveService KeepAliveService
 @inject IMessageService MessageService
+@inject LocalizationService LocalizationService
 
 @code {
     string ConnectionMessageKey = Guid.NewGuid().ToString();
@@ -19,7 +20,7 @@
         {
             Key = ConnectionMessageKey,
             Type = MessageType.Loading,
-            Content = "Lost connection, retrying...",
+            Content = LocalizationService.GetString("LostConnectionRetrying"),
             Duration = 0,
         };
 
@@ -34,7 +35,7 @@
         {
             Key = ConnectionMessageKey,
             Type = MessageType.Loading,
-            Content = $"Lost connection, retrying ({retry.current}/{retry.total}) ...",
+            Content = LocalizationService.GetString("LostConnectionRetryingWithCount", retry.current, retry.total),
             Duration = 0,
         };
 
@@ -47,7 +48,7 @@
         {
             Key = ConnectionMessageKey,
             Type = MessageType.Error,
-            Content = "Server unavailable, enabling offline mode",
+            Content = LocalizationService.GetString("ServerUnavailableEnablingOfflineMode"),
             Duration = 2.5,
         };
 
@@ -60,7 +61,7 @@
         {
             Key = ConnectionMessageKey,
             Type = MessageType.Success,
-            Content = "Connection established!",
+            Content = LocalizationService.GetString("ConnectionEstablished"),
             Duration = 2.5,
         };
 

--- a/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemContextMenu.razor
@@ -10,6 +10,7 @@
 @inject ModalService ModalService
 @inject MessageBusService MessageBusService
 @inject SDK.Client Client
+@inject LocalizationService LocalizationService
 
 @if (GameActions != null && GameActions.Count() > 0)
 {
@@ -30,7 +31,7 @@
         foreach (var manual in Game.Media.Where(m => m.Type == SDK.Enums.MediaType.Manual))
         {
             <MenuItem OnClick="() => OpenManual(manual)">
-                @(String.IsNullOrWhiteSpace(manual.Name) ? "Manual" : manual.Name)
+                @(String.IsNullOrWhiteSpace(manual.Name) ? LocalizationService.GetString("Manual") : manual.Name)
             </MenuItem>
         }
 
@@ -38,36 +39,36 @@
     }
 
     <MenuItem OnClick="() => OpenSaveManager()" Disabled="ConnectionState.OfflineModeEnabled">
-        Manage Saves
+        @LocalizationService.GetString("ManageSaves")
     </MenuItem>
 
     if (Settings.Games.InstallDirectories.Length > 1 || Game.DependentGames.Any(g => g.Type == Data.Enums.GameType.Expansion || g.Type == Data.Enums.GameType.Mod))
     {
         <MenuItem OnClick="() => Modify()" Disabled="ConnectionState.OfflineModeEnabled">
-            Modify
+            @LocalizationService.GetString("Modify")
         </MenuItem>
     }
 
     <MenuItem OnClick="() => BrowseFiles()">
-        Browse Files
+        @LocalizationService.GetString("BrowseFiles")
     </MenuItem>
     <MenuItem OnClick="() => ValidateFiles()" Disabled="ConnectionState.OfflineModeEnabled">
-        Validate Files
+        @LocalizationService.GetString("ValidateFiles")
     </MenuItem>
     <MenuItem OnClick="() => RemoveFromLibrary()" Disabled="ConnectionState.OfflineModeEnabled">
-        Remove
+        @LocalizationService.GetString("Remove")
     </MenuItem>
     <MenuItem OnClick="() => Uninstall()">
-        Uninstall
+        @LocalizationService.GetString("Uninstall")
     </MenuItem>
 }
 else
 {
     <MenuItem OnClick="() => Install()" Disabled="ConnectionState.OfflineModeEnabled">
-        Install
+        @LocalizationService.GetString("Install")
     </MenuItem>
     <MenuItem OnClick="() => RemoveFromLibrary()" Disabled="ConnectionState.OfflineModeEnabled">
-        Remove
+        @LocalizationService.GetString("Remove")
     </MenuItem>
 }
 
@@ -76,26 +77,26 @@ else
     <MenuDivider />
 
     <MenuItem OnClick="() => RunInstallScripts()">
-        Run Install Scripts
+        @LocalizationService.GetString("RunInstallScripts")
     </MenuItem>
 
     <MenuItem OnClick="() => RunUninstallScripts()">
-        Run Uninstall Scripts
+        @LocalizationService.GetString("RunUninstallScripts")
     </MenuItem>
 
     <MenuItem OnClick="() => RunNameChangeScripts()">
-        Run Name Change Scripts
+        @LocalizationService.GetString("RunNameChangeScripts")
     </MenuItem>
 
     <MenuItem OnClick="() => RunKeyChangeScripts()">
-        Run Key Change Scripts
+        @LocalizationService.GetString("RunKeyChangeScripts")
     </MenuItem>
 }
 
 <MenuDivider />
 
 <MenuItem OnClick="() => ReportIssue()" Disabled="ConnectionState.OfflineModeEnabled">
-    Report Issue
+    @LocalizationService.GetString("ReportIssue")
 </MenuItem>
 
 @MenuExtra
@@ -158,7 +159,7 @@ else
         {
             var modalOptions = new ModalOptions()
             {
-                Title = $"Install {Model.Name}",
+                Title = LocalizationService.GetString("InstallGame", Model.Name),
                 Maximizable = false,
                 DefaultMaximized = false,
                 Closable = true,
@@ -182,7 +183,7 @@ else
     {
         var modalOptions = new ModalOptions()
         {
-            Title = $"Modify {Model.Name}",
+            Title = LocalizationService.GetString("ModifyGame", Model.Name),
             Maximizable = false,
             DefaultMaximized = false,
             Closable = true,
@@ -199,13 +200,13 @@ else
     {
         var modalOptions = new ModalOptions()
         {
-            Title = $"File Conflicts",
+            Title = LocalizationService.GetString("FileConflicts"),
             Maximizable = false,
             DefaultMaximized = true,
             Closable = true,
             Draggable = true,
             Centered = true,
-            OkText = "Replace Selected",
+            OkText = LocalizationService.GetString("ReplaceSelected"),
         };
 
         var modalRef = ModalService.CreateModal<ValidateFilesDialog, Game>(modalOptions, Model.DataItem as Game);
@@ -215,18 +216,17 @@ else
     {
         var manifest = await ManifestHelper.ReadAsync<GameManifest>(Game.InstallDirectory, Game.Id);
 
-        var message = $"Would you like to uninstall {Game.Title}?";
-
+        string message;
         if (manifest.SavePaths != null && manifest.SavePaths.Any())
-            message += " Your save files have been uploaded to the server.";
+            message = LocalizationService.GetString("UninstallGameMessageWithSaves", Game.Title);
         else
-            message += " Your save files may be unrecoverable if they are contained within the game's install directory.";
+            message = LocalizationService.GetString("UninstallGameMessageWithoutSaves", Game.Title);
 
         var confirmed = await ModalService.ConfirmAsync(new ConfirmOptions
         {
-            OkText = "Uninstall",
-            CancelText = "Cancel",
-            Title = "Uninstall",
+            OkText = LocalizationService.GetString("UninstallGame"),
+            CancelText = LocalizationService.GetString("Cancel"),
+            Title = LocalizationService.GetString("UninstallGame"),
             Content = message,
             OkButtonProps = new ButtonProps()
             {
@@ -259,7 +259,7 @@ else
 
         var modalOptions = new ModalOptions()
         {
-            Title = $"Remove game from library",
+            Title = LocalizationService.GetString("RemoveGameFromLibrary"),
             Maximizable = false,
             DefaultMaximized = false,
             Closable = true,
@@ -336,7 +336,7 @@ else
     {
         var modalOptions = new ModalOptions()
         {
-            Title = "Manage Saves",
+            Title = LocalizationService.GetString("ManageSaves"),
             Maximizable = false,
             DefaultMaximized = false,
             Closable = true,
@@ -353,11 +353,11 @@ else
     {
         var modalOptions = new ModalOptions()
         {
-            Title = "Report Issue",
+            Title = LocalizationService.GetString("ReportIssue"),
             Maximizable = false,
             DefaultMaximized = false,
             Closable = true,
-            OkText = "Submit",
+            OkText = LocalizationService.GetString("Submit"),
             Draggable = true
         };
 

--- a/LANCommander.Launcher/UI/Components/LibraryItemFilter.razor
+++ b/LANCommander.Launcher/UI/Components/LibraryItemFilter.razor
@@ -7,6 +7,7 @@
 @inject GenreService GenreService
 @inject TagService TagService
 @inject MessageBusService MessageBusService
+@inject LocalizationService LocalizationService
 
 <Flex>
     <Input @bind-Value="LibraryService.Filter.SelectedOptions.Title" TValue="string" AllowClear BindOnInput DebounceMilliseconds="100" OnChange="ApplyFilter" />
@@ -17,16 +18,16 @@
         </ChildContent>
         <ContentTemplate>
             <Form @ref="Form" Model="LibraryService.Filter" OnFinish="ApplyFilter" Layout="@FormLayout.Vertical" Size="FormSize.Small">
-                <FormItem Label="Title">
+                <FormItem Label="@LocalizationService.GetString("Title")">
                     <Input @bind-Value="@context.SelectedOptions.Title" />
                 </FormItem>
-                <FormItem Label="Group By">
+                <FormItem Label="@LocalizationService.GetString("GroupBy")">
                     <Select @bind-Value="@context.SelectedOptions.GroupBy" TItem="GroupBy" TItemValue="GroupBy" DataSource="Enum.GetValues<GroupBy>()">
                         <LabelTemplate Context="Value">@Value.GetDisplayName()</LabelTemplate>
                         <ItemTemplate Context="Value">@Value.GetDisplayName()</ItemTemplate>
                     </Select>
                 </FormItem>
-                <FormItem Label="Sort By">
+                <FormItem Label="@LocalizationService.GetString("SortBy")">
                     <Flex>
                         <Select @bind-Value="@context.SelectedOptions.SortBy" TItem="SortBy" TItemValue="SortBy" DataSource="Enum.GetValues<SortBy>()">
                             <LabelTemplate Context="Value">@Value.GetDisplayName()</LabelTemplate>
@@ -43,36 +44,36 @@
                         }
                     </Flex>
                 </FormItem>
-                <FormItem Label="Engine">
+                <FormItem Label="@LocalizationService.GetString("Engine")">
                     <TagsInput Entities="context.DataSource.Engines" @bind-Values="@context.SelectedOptions.Engines" OptionLabelSelector="e => e.Name" TItem="Engine" />
                 </FormItem>
-                <FormItem Label="Genre">
+                <FormItem Label="@LocalizationService.GetString("Genre")">
                     <TagsInput Entities="context.DataSource.Genres" @bind-Values="@context.SelectedOptions.Genres" OptionLabelSelector="g => g.Name" TItem="Genre" />
                 </FormItem>
-                <FormItem Label="Tag">
+                <FormItem Label="@LocalizationService.GetString("Tag")">
                     <TagsInput Entities="context.DataSource.Tags" @bind-Values="@context.SelectedOptions.Tags" OptionLabelSelector="t => t.Name" TItem="Data.Models.Tag" />
                 </FormItem>
-                <FormItem Label="Platform">
+                <FormItem Label="@LocalizationService.GetString("Platform")">
                     <TagsInput Entities="context.DataSource.Platforms" @bind-Values="@context.SelectedOptions.Platforms" OptionLabelSelector="p => p.Name" TItem="Platform" />
                 </FormItem>
-                <FormItem Label="Developers">
+                <FormItem Label="@LocalizationService.GetString("Developers")">
                     <TagsInput Entities="context.DataSource.Developers" @bind-Values="@context.SelectedOptions.Developers" OptionLabelSelector="c => c.Name" TItem="Company" />
                 </FormItem>
-                <FormItem Label="Publishers">
+                <FormItem Label="@LocalizationService.GetString("Publishers")">
                     <TagsInput Entities="context.DataSource.Publishers" @bind-Values="@context.SelectedOptions.Publishers" OptionLabelSelector="c => c.Name" TItem="Company" />
                 </FormItem>
-                <FormItem Label="Players">
+                <FormItem Label="@LocalizationService.GetString("Players")">
                     <InputGroup Compact>
-                        <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MinPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="Minimum" Style="flex-grow: 1;" />
+                        <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MinPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="@LocalizationService.GetString("Minimum")" Style="flex-grow: 1;" />
                         <Input TValue="string" InputElementSuffixClass="site-input-split" Style="width: 30px; border-left: 0; border-right: 0; pointer-events: none; text-align: center;" Placeholder="~" Disabled />
-                        <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MaxPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="Maximum" Style="flex-grow: 1;" />
+                        <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MaxPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="@LocalizationService.GetString("Maximum")" Style="flex-grow: 1;" />
                     </InputGroup>
                 </FormItem>
                 <FormItem>
-                    <Checkbox @bind-Value="@context.SelectedOptions.Installed">Installed</Checkbox>
+                    <Checkbox @bind-Value="@context.SelectedOptions.Installed">@LocalizationService.GetString("Installed")</Checkbox>
                 </FormItem>
                 <FormItem>
-                    <Button Type="ButtonType.Primary" HtmlType="submit">Apply</Button>
+                    <Button Type="ButtonType.Primary" HtmlType="submit">@LocalizationService.GetString("Apply")</Button>
                     <Button Type="@ButtonType.Text" OnClick="ResetFilter" Icon="@IconType.Outline.Close" Danger />
                 </FormItem>
             </Form>

--- a/LANCommander.Launcher/UI/Components/PlayButton.razor
+++ b/LANCommander.Launcher/UI/Components/PlayButton.razor
@@ -10,26 +10,27 @@
 @inject ModalService ModalService
 @inject MessageService MessageService
 @inject MessageBusService MessageBusService
+@inject LocalizationService LocalizationService
 
 @if (State == PlayButtonState.Running)
 {
-    <Popconfirm Title="Do you want to stop this game?" OkText="Yes" OnConfirm="() => Stop()">
-        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.CaretRight">Running</Button>
+    <Popconfirm Title="@LocalizationService.GetString("DoYouWantToStopGame")" OkText="@LocalizationService.GetString("Yes")" OnConfirm="() => Stop()">
+        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.CaretRight">@LocalizationService.GetString("Running")</Button>
     </Popconfirm>
 }
 else if (State == PlayButtonState.Starting)
 {
-    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading="true">Starting</Button>
+    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading="true">@LocalizationService.GetString("Starting")</Button>
 }
 else if (State == PlayButtonState.Stopping)
 {
-    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading="true">Stopping</Button>
+    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading="true">@LocalizationService.GetString("Stopping")</Button>
 }
 else
 {
     <Space Direction="SpaceDirection.Horizontal">
         <SpaceItem>
-            <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.CaretRight" OnClick="() => Run()">Play</Button>
+            <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.CaretRight" OnClick="() => Run()">@LocalizationService.GetString("Play")</Button>
         </SpaceItem>
 
         <SpaceItem>
@@ -105,7 +106,7 @@ else
 
         if (actions == null || actions.Count() == 0)
         {
-            MessageService.Error("No actions found!");
+            MessageService.Error(LocalizationService.GetString("NoActionsFound"));
 
             await ChangeState(PlayButtonState.Idle);
             return;
@@ -115,7 +116,7 @@ else
 
         if (primaryActions.Count() == 0)
         {
-            MessageService.Error("No primary action found!");
+            MessageService.Error(LocalizationService.GetString("NoPrimaryActionFound"));
             
             await ChangeState(PlayButtonState.Idle);
             return;
@@ -133,7 +134,7 @@ else
         {
             var modalOptions = new ModalOptions()
             {
-                Title = $"Play {game.Title}",
+                Title = LocalizationService.GetString("PlayGame", game.Title),
                 Maximizable = false,
                 DefaultMaximized = false,
                 Closable = true,

--- a/LANCommander.Launcher/UI/Components/ProfileButton.razor
+++ b/LANCommander.Launcher/UI/Components/ProfileButton.razor
@@ -5,26 +5,27 @@
 @inject AuthenticationService AuthenticationService
 @inject NavigationManager NavigationManager
 @inject ModalService ModalService
+@inject LocalizationService LocalizationService
 
 <Dropdown>
     <Overlay>
         <Menu>
             <MenuItem OnClick="ChangeAlias" Disabled="ConnectionState.OfflineModeEnabled">
-                Change Name
+                @LocalizationService.GetString("ChangeName")
             </MenuItem>
             <MenuItem OnClick="@(() => NavigationManager.NavigateTo("/Settings"))">
-                Settings
+                @LocalizationService.GetString("Settings")
             </MenuItem>
 
             @if (!Settings.Authentication.OfflineMode)
             {
                 <MenuItem OnClick="SwitchToOfflineMode">
-                    Switch to offline mode
+                    @LocalizationService.GetString("SwitchToOfflineMode")
                 </MenuItem>
             }
 
             <MenuItem OnClick="Logout">
-                Logout
+                @LocalizationService.GetString("Logout")
             </MenuItem>
         </Menu>
     </Overlay>
@@ -75,7 +76,7 @@
     {
         var modalOptions = new ModalOptions()
             {
-                Title = "Change Name",
+                Title = LocalizationService.GetString("ChangeName"),
                 Maximizable = false,
                 DefaultMaximized = false,
                 Closable = true,

--- a/LANCommander.Launcher/UI/Components/RemoveFromLibraryDialog.razor
+++ b/LANCommander.Launcher/UI/Components/RemoveFromLibraryDialog.razor
@@ -5,19 +5,20 @@
 @inject LibraryService LibraryService
 @inject IMessageService MessageService
 @inject ILogger<RemoveFromLibraryDialog> Logger
+@inject LocalizationService LocalizationService
 
 <div class="remove-from-library-dialog" style="padding: 16px;">
     <div class="game-item">
         <div class="icon">
             <MediaImage Id="@Options.IconId" />
         </div>
-        <span class="title-pre">Base Game</span>
+        <span class="title-pre">@LocalizationService.GetString("BaseGame")</span>
         <span class="title">@Options.Name</span>
     </div>
 
     @if (DependentGames.Any())
     {
-        <Divider Text="Addons to remove" Orientation="DividerOrientation.Left" Plain  />
+        <Divider Text="@LocalizationService.GetString("AddonsToRemove")" Orientation="DividerOrientation.Left" Plain  />
 
         <CheckboxButtonGroup @bind-Selected="SelectedDependentGames" DataSource="DependentGames" 
         KeySelector="a => a.Id" 
@@ -33,8 +34,8 @@
 </div>
 
 <Flex Gap="FlexGap.Middle" Style="padding: 16px; padding-top: 0px" Justify="FlexJustify.FlexEnd">
-    <Button Type="ButtonType.Primary" OnClick="RemoveFromLibrary">Remove</Button>
-    <Button OnClick="() => Close()">Close</Button>
+    <Button Type="ButtonType.Primary" OnClick="RemoveFromLibrary">@LocalizationService.GetString("Remove")</Button>
+    <Button OnClick="() => Close()">@LocalizationService.GetString("Close")</Button>
 </Flex>
 
 @code {
@@ -74,7 +75,7 @@
             }
             catch (Exception ex)
             {
-                MessageService.Error("Could not remove game");
+                MessageService.Error(LocalizationService.GetString("CouldNotRemoveGame"));
                 Logger?.LogError(ex, "Could not remove game {GameTitle}", game.Title);
             }
         }

--- a/LANCommander.Launcher/UI/Components/ReportIssueDialog.razor
+++ b/LANCommander.Launcher/UI/Components/ReportIssueDialog.razor
@@ -2,6 +2,7 @@
 @inherits FeedbackComponent<Data.Models.Game, SDK.Models.Issue>
 @inject SDK.Client Client
 @inject IMessageService MessageService
+@inject LocalizationService LocalizationService
 
 <Form Model="Issue">
     <FormItem Style="margin-bottom: 0">
@@ -21,20 +22,20 @@
 
             if (success)
             {
-                MessageService.Success("Issue reported!");
+                MessageService.Success(LocalizationService.GetString("IssueReported"));
 
                 await base.FeedbackRef.CloseAsync();
             }
             else
             {
-                MessageService.Error("Unknown error: issue not reported");
+                MessageService.Error(LocalizationService.GetString("UnknownErrorIssueNotReported"));
 
                 args.Reject();
             }
         }
         catch (Exception ex)
         {
-            MessageService.Error("Unknown error: issue not reported");
+            MessageService.Error(LocalizationService.GetString("UnknownErrorIssueNotReported"));
 
             args.Reject();
         }

--- a/LANCommander.Launcher/UI/Components/SavesDialog.razor
+++ b/LANCommander.Launcher/UI/Components/SavesDialog.razor
@@ -2,19 +2,20 @@
 @inherits FeedbackComponent<Data.Models.Game>
 @inject SaveService SaveService
 @inject IMessageService MessageService
+@inject LocalizationService LocalizationService
 
 <Table DataSource="Saves" Size="TableSize.Small" PageIndex="@CurrentPage" PageSize="@PageSize" PaginationPosition="none">
-    <PropertyColumn Property="s => s.CreatedOn" Title="Created On" />
+    <PropertyColumn Property="s => s.CreatedOn" Title="@LocalizationService.GetString("CreatedOn")" />
     <PropertyColumn Property="s => s.Size">
         <ByteSize Value="context.Size" />
     </PropertyColumn>
     <ActionColumn>
         <Flex Justify="FlexJustify.End">
-            <Popconfirm Title="Are you sure? This will replace any local save files!" OnConfirm="() => Download(context)">
+            <Popconfirm Title="@LocalizationService.GetString("AreYouSureReplaceLocalSaves")" OnConfirm="() => Download(context)">
                 <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Download" />
             </Popconfirm>
 
-            <Popconfirm Title="Are you sure you want to delete this save?" OnConfirm="() => Delete(context)">
+            <Popconfirm Title="@LocalizationService.GetString("AreYouSureDeleteSave")" OnConfirm="() => Delete(context)">
                 <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Close" Danger />
             </Popconfirm>
         </Flex>
@@ -32,10 +33,10 @@
     <GridCol>
         <Space Direction="SpaceDirection.Horizontal">
             <SpaceItem>
-                <Button OnClick="() => Upload()">Upload</Button>
+                <Button OnClick="() => Upload()">@LocalizationService.GetString("Upload")</Button>
             </SpaceItem>
             <SpaceItem>
-                <Button Type="ButtonType.Primary" OnClick="() => Close()">Close</Button>
+                <Button Type="ButtonType.Primary" OnClick="() => Close()">@LocalizationService.GetString("Close")</Button>
             </SpaceItem>
         </Space>
     </GridCol>
@@ -61,14 +62,14 @@
     {
         await SaveService.DownloadAsync(Options.InstallDirectory, Options.Id, save.Id);
 
-        MessageService.Success("Save downloaded!");
+        MessageService.Success(LocalizationService.GetString("SaveDownloaded"));
     }
 
     async Task Delete(GameSave save)
     {
         await SaveService.DeleteAsync(save.Id);
 
-        MessageService.Success("Save deleted!");
+        MessageService.Success(LocalizationService.GetString("SaveDeleted"));
 
         await LoadData();
     }
@@ -77,7 +78,7 @@
     {
         await SaveService.UploadAsync(Options.InstallDirectory, Options.Id);
 
-        MessageService.Success("Save uploaded!");
+        MessageService.Success(LocalizationService.GetString("SaveUploaded"));
 
         await LoadData();
     }

--- a/LANCommander.Launcher/UI/Components/UpdateChecker.razor
+++ b/LANCommander.Launcher/UI/Components/UpdateChecker.razor
@@ -2,6 +2,7 @@
 @using Semver
 @inject UpdateService UpdateService
 @inject ModalService ModalService
+@inject LocalizationService LocalizationService
 
 @code {
     protected override async Task OnInitializedAsync()
@@ -13,10 +14,10 @@
     {
         var confirmUpdate = await ModalService.ConfirmAsync(new ConfirmOptions
         {
-            OkText = "Update Now",
-            CancelText = "Later",
-            Title = "Launcher Update",
-            Content = $"An update for v{response.Version} is available. Do you want to download and install?",
+            OkText = LocalizationService.GetString("UpdateNow"),
+            CancelText = LocalizationService.GetString("Later"),
+            Title = LocalizationService.GetString("LauncherUpdate"),
+            Content = LocalizationService.GetString("UpdateAvailableMessage", response.Version),
             Centered = true
         });
 

--- a/LANCommander.Launcher/UI/Components/ValidateFilesDialog.razor
+++ b/LANCommander.Launcher/UI/Components/ValidateFilesDialog.razor
@@ -3,29 +3,30 @@
 @inject SaveService SaveService
 @inject SDK.Client Client
 @inject IMessageService MessageService
+@inject LocalizationService LocalizationService
 
 <Table DataSource="Conflicts" Resizable Size="TableSize.Small" RowKey="c => c.FullName" @bind-SelectedRows="Selected" Loading="Loading">
     <Selection Type="SelectionType.Checkbox" />
-    <PropertyColumn Property="c => c.FullName" Title="Name" />
-    <Column TData="string" Title="Created">
+    <PropertyColumn Property="c => c.FullName" Title="@LocalizationService.GetString("Name")" />
+    <Column TData="string" Title="@LocalizationService.GetString("Created")">
         @context.LocalFileInfo?.CreationTime
     </Column>
-    <Column TData="string" Title="Modified">
+    <Column TData="string" Title="@LocalizationService.GetString("Modified")">
         @context.LocalFileInfo?.LastWriteTime
     </Column>
-    <Column TData="string" Title="Local Size">
+    <Column TData="string" Title="@LocalizationService.GetString("LocalSize")">
         @if (context.LocalFileInfo?.Length > 0)
         {
             <ByteSize Value="context.LocalFileInfo.Length" />
         }
     </Column>
-    <PropertyColumn Property="c => c.Length" Title="Original Size">
+    <PropertyColumn Property="c => c.Length" Title="@LocalizationService.GetString("OriginalSize")">
         @if (context.Length > 0)
         {
             <ByteSize Value="context.Length" />
         }
     </PropertyColumn>
-    <Column TData="string" Title="Source Game">
+    <Column TData="string" Title="@LocalizationService.GetString("SourceGame")">
         @{
             GameTitleMap.TryGetValue(context.GameId.GetValueOrDefault(Guid.Empty), out var title);
         }

--- a/LANCommander.Launcher/UI/Depot/Components/DepotFilter.razor
+++ b/LANCommander.Launcher/UI/Depot/Components/DepotFilter.razor
@@ -1,22 +1,23 @@
 ﻿@using LANCommander.Launcher.Models.Enums
 @using LANCommander.SDK.Models
 @inject DepotService DepotService
+@inject LocalizationService LocalizationService
 
 <div class="depot-filter">
     <Form @ref="Form" Model="DepotService.Filter" OnFinish="DepotService.UpdateFilterAsync" Layout="@FormLayout.Vertical">
         <FormItem>
             <Slider @bind-Value="ColumnSize" Step="50" Min="100" Max="250" />
         </FormItem>
-        <FormItem Label="Title">
+        <FormItem Label="@LocalizationService.GetString("Title")">
             <Input @bind-Value="@context.SelectedOptions.Title" AutoFocus />
         </FormItem>
-        <FormItem Label="Group By">
+        <FormItem Label="@LocalizationService.GetString("GroupBy")">
             <Select @bind-Value="@context.SelectedOptions.GroupBy" TItem="GroupBy" TItemValue="GroupBy" DataSource="Enum.GetValues<GroupBy>()">
                 <LabelTemplate Context="Value">@Value.GetDisplayName()</LabelTemplate>
                 <ItemTemplate Context="Value">@Value.GetDisplayName()</ItemTemplate>
             </Select>
         </FormItem>
-        <FormItem Label="Sort By">
+        <FormItem Label="@LocalizationService.GetString("SortBy")">
             <Flex>
                 <Select @bind-Value="@context.SelectedOptions.SortBy" TItem="SortBy" TItemValue="SortBy" DataSource="Enum.GetValues<SortBy>()">
                     <LabelTemplate Context="Value">@Value.GetDisplayName()</LabelTemplate>
@@ -33,36 +34,36 @@
                 }
             </Flex>
         </FormItem>
-        <FormItem Label="Engine">
+        <FormItem Label="@LocalizationService.GetString("Engine")">
             <TagsInput Entities="context.DataSource.Engines" @bind-Values="@context.SelectedOptions.Engines" OptionLabelSelector="e => e.Name" TItem="Engine" />
         </FormItem>
-        <FormItem Label="Collection">
+        <FormItem Label="@LocalizationService.GetString("Collection")">
             <TagsInput Entities="context.DataSource.Collections" @bind-Values="@context.SelectedOptions.Collections" OptionLabelSelector="c => c.Name" TItem="Collection" />
         </FormItem>
-        <FormItem Label="Genre">
+        <FormItem Label="@LocalizationService.GetString("Genre")">
             <TagsInput Entities="context.DataSource.Genres" @bind-Values="@context.SelectedOptions.Genres" OptionLabelSelector="g => g.Name" TItem="Genre" />
         </FormItem>
-        <FormItem Label="Tag">
+        <FormItem Label="@LocalizationService.GetString("Tag")">
             <TagsInput Entities="context.DataSource.Tags" @bind-Values="@context.SelectedOptions.Tags" OptionLabelSelector="t => t.Name" TItem="SDK.Models.Tag" />
         </FormItem>
-        <FormItem Label="Platform">
+        <FormItem Label="@LocalizationService.GetString("Platform")">
             <TagsInput Entities="context.DataSource.Platforms" @bind-Values="@context.SelectedOptions.Platforms" OptionLabelSelector="p => p.Name" TItem="Platform" />
         </FormItem>
-        <FormItem Label="Developers">
+        <FormItem Label="@LocalizationService.GetString("Developers")">
             <TagsInput Entities="context.DataSource.Developers" @bind-Values="@context.SelectedOptions.Developers" OptionLabelSelector="c => c.Name" TItem="Company" />
         </FormItem>
-        <FormItem Label="Publishers">
+        <FormItem Label="@LocalizationService.GetString("Publishers")">
             <TagsInput Entities="context.DataSource.Publishers" @bind-Values="@context.SelectedOptions.Publishers" OptionLabelSelector="c => c.Name" TItem="Company" />
         </FormItem>
-        <FormItem Label="Players">
+        <FormItem Label="@LocalizationService.GetString("Players")">
             <InputGroup Compact>
-                <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MinPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="Minimum" Style="flex-grow: 1;" />
+                <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MinPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="@LocalizationService.GetString("Minimum")" Style="flex-grow: 1;" />
                 <Input TValue="string" InputElementSuffixClass="site-input-split" Style="width: 30px; border-left: 0; border-right: 0; pointer-events: none; text-align: center;" Placeholder="~" Disabled />
-                <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MaxPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="Maximum" Style="flex-grow: 1;" />
+                <AntDesign.InputNumber @bind-Value="@context.SelectedOptions.MaxPlayers" Min="@context.DataSource.MinPlayers" Max="@context.DataSource.MaxPlayers" PlaceHolder="@LocalizationService.GetString("Maximum")" Style="flex-grow: 1;" />
             </InputGroup>
         </FormItem>
         <FormItem>
-            <Button Type="ButtonType.Primary" HtmlType="submit">Apply</Button>
+            <Button Type="ButtonType.Primary" HtmlType="submit">@LocalizationService.GetString("Apply")</Button>
             <Button Type="@ButtonType.Text" OnClick="DepotService.ResetFilterAsync" Icon="@IconType.Outline.Close" Danger />
         </FormItem>
     </Form>

--- a/LANCommander.Launcher/UI/Depot/Components/DepotGameDetails.razor
+++ b/LANCommander.Launcher/UI/Depot/Components/DepotGameDetails.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager NavigationManager
 @inject ModalService ModalService
 @inject IMessageService MessageService
+@inject LocalizationService LocalizationService
 
 <Drawer Placement="DrawerPlacement.Bottom" Class="depot-game-details" @bind-Visible="@Visible" OnClose="Hide">
     @if (SelectedGame != null)
@@ -39,27 +40,27 @@
                                     {
                                         if (IsInLibrary)
                                         {
-                                            <Button Type="ButtonType.Primary" Size="ButtonSize.Large" OnClick="ViewInLibrary">View in Library</Button>
+                                            <Button Type="ButtonType.Primary" Size="ButtonSize.Large" OnClick="ViewInLibrary">@LocalizationService.GetString("ViewInLibrary")</Button>
                                         }
                                         else
                                         {
-                                            <Button Type="ButtonType.Dashed" Size="ButtonSize.Large" Style="pointer-events: none;">Installed</Button>
+                                            <Button Type="ButtonType.Dashed" Size="ButtonSize.Large" Style="pointer-events: none;">@LocalizationService.GetString("Installed")</Button>
                                         }
                                     }
                                     else
                                     {
-                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="Install" Loading="Installing">Install</Button>
+                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="Install" Loading="Installing">@LocalizationService.GetString("Install")</Button>
                                     }
 
                                     @if (IsInLibrary || SelectedGame.InLibrary)
                                     {
-                                        <Tooltip Title="Remove from Library">
+                                        <Tooltip Title="@LocalizationService.GetString("RemoveFromLibrary")">
                                             <Button Size="ButtonSize.Large" Type="@ButtonType.Text" Icon="@IconType.Outline.Close" Danger OnClick="RemoveFromLibrary" Loading="RemovingFromLibrary" />
                                         </Tooltip>
                                     }
                                     else
                                     {
-                                        <Tooltip Title="Add to Library">
+                                        <Tooltip Title="@LocalizationService.GetString("AddToLibrary")">
                                             <Button Size="ButtonSize.Large" Type="@ButtonType.Text" Icon="@IconType.Outline.Plus" OnClick="AddToLibrary" Loading="AddingToLibrary" />
                                         </Tooltip>
                                     }
@@ -68,17 +69,17 @@
                                 @if (!IsInstalled && Client.IsConnected())
                                 {
                                     <SpaceItem>
-                                        <Statistic Title="Download Size" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()" />
+                                        <Statistic Title="@LocalizationService.GetString("DownloadSize")" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()" />
                                     </SpaceItem>
                                 }
 
                                 @if (SelectedGame.PlaySessions.HasAny())
                                 {
                                     <SpaceItem>
-                                        <Statistic Title="Play Time" Value="@GetPlayTime(SelectedGame)" />
-                                    </SpaceItem>
-                                    <SpaceItem>
-                                        <Statistic Title="Last Played" Value="@GetLastPlayed(SelectedGame)" />
+                                                                            <Statistic Title="@LocalizationService.GetString("PlayTime")" Value="@GetPlayTime(SelectedGame)" />
+                                </SpaceItem>
+                                <SpaceItem>
+                                    <Statistic Title="@LocalizationService.GetString("LastPlayed")" Value="@GetLastPlayed(SelectedGame)" />
                                     </SpaceItem>
                                 }
                             </Space>
@@ -93,7 +94,7 @@
                             @if (SelectedGame!.ReleasedOn > DateTime.MinValue)
                             {
                                 <div class="game-metadata-released-on">
-                                    <h3>Released On</h3>
+                                    <h3>@LocalizationService.GetString("ReleasedOn")</h3>
                                     <span>@SelectedGame.ReleasedOn.ToString("MMMM d, yyyy")</span>
                                 </div>
                             }
@@ -101,7 +102,7 @@
                             @if (SelectedGame.Developers.HasAny())
                             {
                                 <div class="game-metadata-developers">
-                                    <h3>Developers</h3>
+                                    <h3>@LocalizationService.GetString("Developers")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Developers.Select(c => c.Name)))</span>
                                 </div>
                             }
@@ -109,7 +110,7 @@
                             @if (SelectedGame.Publishers.HasAny())
                             {
                                 <div class="game-metadata-publishers">
-                                    <h3>Publishers</h3>
+                                    <h3>@LocalizationService.GetString("Publishers")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Publishers.Select(c => c.Name)))</span>
                                 </div>
                             }
@@ -117,7 +118,7 @@
                             @if (SelectedGame.Genres.HasAny())
                             {
                                 <div class="game-metadata-genres">
-                                    <h3>Genres</h3>
+                                    <h3>@LocalizationService.GetString("Genres")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Genres.Select(g => g.Name)))</span>
                                 </div>
                             }
@@ -125,7 +126,7 @@
                             @if (SelectedGame.Tags.HasAny())
                             {
                                 <div class="game-metadata-tags">
-                                    <h3>Tags</h3>
+                                    <h3>@LocalizationService.GetString("Tags")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Tags.Select(t => t.Name)))</span>
                                 </div>
                             }

--- a/LANCommander.Launcher/UI/Depot/Components/DepotGameItem.razor
+++ b/LANCommander.Launcher/UI/Depot/Components/DepotGameItem.razor
@@ -5,6 +5,7 @@
 @inject ImportService ImportService
 @inject IMessageService MessageService
 @inject ILogger<DepotGame> Logger
+@inject LocalizationService LocalizationService
 
 <div class="depot-game">
     <div class="depot-game-cover" @onclick="() => OnClick.InvokeAsync(Item)">
@@ -52,7 +53,7 @@
             StateHasChanged();
             await Task.Yield();
 
-            MessageService.Success($"{Item.Name} was added to your library!");
+            MessageService.Success(LocalizationService.GetString("GameAddedToLibrary", Item.Name));
         }
         catch (Exception ex)
         {
@@ -61,7 +62,7 @@
             await Task.Yield();
 
             Logger?.LogError(ex, $"{Item.Name} ({Item.Key}) could not be added to your library!");
-            MessageService.Error($"{Item.Name} could not be added to your library!");
+            MessageService.Error(LocalizationService.GetString("GameCouldNotBeAddedToLibrary", Item.Name));
         }
     }
 }

--- a/LANCommander.Launcher/UI/Depot/Components/DepotList.razor
+++ b/LANCommander.Launcher/UI/Depot/Components/DepotList.razor
@@ -1,5 +1,6 @@
 ﻿@inject SDK.Client Client
 @inject DepotService DepotService
+@inject LocalizationService LocalizationService
 
 <Spin Spinning="!Loaded" WrapperClassName="depot-list-spinner">
     @if (ListItems.Any())
@@ -34,14 +35,14 @@
     }
     else if (DepotService.GetItemCount() > 0)
     {
-        <Result Title="No Results" />
+        <Result Title="@LocalizationService.GetString("NoResults")" />
     }
     else if (Loaded)
     {
         <Result
         Status="ResultStatus.Error"
-        Title="No Results"
-        SubTitle="The depot is empty or you are unauthorized. Contact your adminstrator." />
+        Title="@LocalizationService.GetString("NoResults")"
+        SubTitle="@LocalizationService.GetString("DepotEmptyOrUnauthorized")" />
     }
 </Spin>
 
@@ -75,7 +76,7 @@
         Groups = ListItems.DistinctBy(i => i.Key).SelectMany(i => i.Groups).Distinct().ToList();
 
         if (ListItems.DistinctBy(i => i.Key).Any(i => i.Groups == null || i.Groups.Length == 0))
-            Groups.Add("Uncategorized");
+            Groups.Add(LocalizationService.GetString("Uncategorized"));
 
         await InvokeAsync(StateHasChanged);
     }

--- a/LANCommander.Launcher/UI/Depot/Index.razor
+++ b/LANCommander.Launcher/UI/Depot/Index.razor
@@ -10,6 +10,7 @@
 @inject KeepAliveService KeepAliveService
 @inject MessageService MessageService
 @inject ILogger<Index> Logger
+@inject LocalizationService LocalizationService
 
 <Spin Spinning="Disabled">
     <Layout>
@@ -57,12 +58,12 @@
         }
         catch (DepotNoResultsException ex)
         {
-            MessageService.Error("Depot results could not be fetched");
+            MessageService.Error(LocalizationService.GetString("DepotResultsCouldNotBeFetched"));
             Logger?.LogError(ex, "The depot returned no results");
         }
         catch (Exception ex)
         {
-            MessageService.Error("Unexpected error fetching depot results");
+            MessageService.Error(LocalizationService.GetString("UnexpectedErrorFetchingDepotResults"));
             Logger?.LogError(ex, "Unexpected error fetching depot results");
         }
     }

--- a/LANCommander.Launcher/UI/Library/Components/LibraryList.razor
+++ b/LANCommander.Launcher/UI/Library/Components/LibraryList.razor
@@ -5,20 +5,21 @@
 @inject ImportService ImportService
 @inject MessageBusService MessageBusService
 @inject NavigationManager NavigationManager
+@inject LocalizationService LocalizationService
 
 <Flex Vertical Class="library-list">
     @if (LibraryService.Items == null || !LibraryService.Items.Any())
     {
         <Empty Simple Description="false">
-            <Button Type="ButtonType.Primary" OnClick="@(() => NavigationManager.NavigateTo("/Depot"))">Browse Depot</Button>
+            <Button Type="ButtonType.Primary" OnClick="@(() => NavigationManager.NavigateTo("/Depot"))">@LocalizationService.GetString("BrowseDepot")</Button>
         </Empty>
     }
     else
     {
         if (LibraryItems == null || !LibraryItems.Any())
         {
-            <Empty Simple Description="@("No Results Found")">
-                <Button Type="ButtonType.Primary" OnClick="Filter.ResetFilter">Reset Filter</Button>
+            <Empty Simple Description="@LocalizationService.GetString("NoResultsFound")">
+                <Button Type="ButtonType.Primary" OnClick="Filter.ResetFilter">@LocalizationService.GetString("ResetFilter")</Button>
             </Empty>
         }
         else
@@ -84,7 +85,7 @@
         Groups = LibraryItems.SelectMany(i => i.Groups).Distinct().ToList();
 
         if (LibraryItems.Any(i => i.Groups == null || i.Groups.Length == 0))
-            Groups.Add("Uncategorized");
+            Groups.Add(LocalizationService.GetString("Uncategorized"));
 
         await InvokeAsync(StateHasChanged);
     }

--- a/LANCommander.Launcher/UI/Library/Index.razor
+++ b/LANCommander.Launcher/UI/Library/Index.razor
@@ -14,6 +14,7 @@
 @inject ModalService ModalService
 @inject ConfirmService ConfirmService
 @inject ImportService ImportService
+@inject LocalizationService LocalizationService
 
 <Layout>
     <Content Class="library">
@@ -50,39 +51,39 @@
                                     {
                                         <ConnectionStateView>
                                             <Online>
-                                                <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="() => Install(SelectedItem)">Install</Button>
+                                                <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="() => Install(SelectedItem)">@LocalizationService.GetString("Install")</Button>
                                             </Online>
                                             <Offline>
-                                                <Tooltip Title="You are currently offline">
-                                                    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" Disabled>Install</Button>
+                                                <Tooltip Title="@LocalizationService.GetString("YouAreCurrentlyOffline")">
+                                                    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" Disabled>@LocalizationService.GetString("Install")</Button>
                                                 </Tooltip>
                                             </Offline>
                                         </ConnectionStateView>
                                     }
                                     else if (SelectedItem.State == ListItemState.Queued)
                                     {
-                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Bars" Disabled="true">Queued</Button>
+                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Bars" Disabled="true">@LocalizationService.GetString("Queued")</Button>
                                     }
                                     else if (SelectedItem.State == ListItemState.UpdateAvailable)
                                     {
                                         <ConnectionStateView>
                                             <Online>
-                                                <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="() => Update(SelectedItem)">Update</Button>
+                                                <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" OnClick="() => Update(SelectedItem)">@LocalizationService.GetString("Update")</Button>
                                             </Online>
                                             <Offline>
-                                                <Tooltip Title="You are currently offline">
-                                                    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" Disabled>Update</Button>
+                                                <Tooltip Title="@LocalizationService.GetString("YouAreCurrentlyOffline")">
+                                                    <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Icon="@IconType.Outline.Download" Disabled>@LocalizationService.GetString("Update")</Button>
                                                 </Tooltip>
                                             </Offline>
                                         </ConnectionStateView>
                                     }
                                     else if (SelectedItem.State == ListItemState.Installing)
                                     {
-                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading Disabled="true">Installing</Button>
+                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading Disabled="true">@LocalizationService.GetString("Installing")</Button>
                                     }
                                     else if (SelectedItem.State == ListItemState.Uninstalling)
                                     {
-                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading Disabled="true">Uninstalling</Button>
+                                        <Button Type="ButtonType.Primary" Size="ButtonSize.Large" Loading Disabled="true">@LocalizationService.GetString("Uninstalling")</Button>
                                     }
                                 </SpaceItem>
 
@@ -91,17 +92,17 @@
                                     <ConnectionStateView>
                                         <Online>
                                             <SpaceItem>
-                                                <Statistic Title="Download Size" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()"/>
+                                                <Statistic Title="@LocalizationService.GetString("DownloadSize")" Value="@ByteSizeLib.ByteSize.FromBytes(GetDownloadSize()).ToString()"/>
                                             </SpaceItem>
                                         </Online>
                                     </ConnectionStateView>
                                 }
 
                                 <SpaceItem>
-                                    <Statistic Title="Play Time" Value="@GetPlayTime(SelectedGame)" />
+                                    <Statistic Title="@LocalizationService.GetString("PlayTime")" Value="@GetPlayTime(SelectedGame)" />
                                 </SpaceItem>
                                 <SpaceItem>
-                                    <Statistic Title="Last Played" Value="@GetLastPlayed(SelectedGame)" />
+                                    <Statistic Title="@LocalizationService.GetString("LastPlayed")" Value="@GetLastPlayed(SelectedGame)" />
                                 </SpaceItem>
                             </Space>
                         </div>
@@ -115,7 +116,7 @@
                             @if (SelectedGame.ReleasedOn.HasValue)
                             {
                                 <div class="game-metadata-released-on">
-                                    <h3>Released On</h3>
+                                    <h3>@LocalizationService.GetString("ReleasedOn")</h3>
                                     <span>@SelectedGame.ReleasedOn.Value.ToString("MMMM d, yyyy")</span>
                                 </div>
                             }
@@ -123,7 +124,7 @@
                             @if (SelectedGame.Developers != null && SelectedGame.Developers.Any())
                             {
                                 <div class="game-metadata-developers">
-                                    <h3>Developers</h3>
+                                    <h3>@LocalizationService.GetString("Developers")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Developers.Select(c => c.Name)))</span>
                                 </div>
                             }
@@ -131,7 +132,7 @@
                             @if (SelectedGame.Publishers != null && SelectedGame.Publishers.Any())
                             {
                                 <div class="game-metadata-publishers">
-                                    <h3>Publishers</h3>
+                                    <h3>@LocalizationService.GetString("Publishers")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Publishers.Select(c => c.Name)))</span>
                                 </div>
                             }
@@ -139,7 +140,7 @@
                             @if (SelectedGame.Genres != null && SelectedGame.Genres.Any())
                             {
                                 <div class="game-metadata-genres">
-                                    <h3>Genres</h3>
+                                    <h3>@LocalizationService.GetString("Genres")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Genres.Select(g => g.Name)))</span>
                                 </div>
                             }
@@ -147,7 +148,7 @@
                             @if (SelectedGame.Tags != null && SelectedGame.Tags.Any())
                             {
                                 <div class="game-metadata-tags">
-                                    <h3>Tags</h3>
+                                    <h3>@LocalizationService.GetString("Tags")</h3>
                                     <span>@(String.Join(", ", SelectedGame.Tags.Select(t => t.Name)))</span>
                                 </div>
                             }
@@ -242,11 +243,11 @@
         {
             var modalOptions = new ModalOptions()
             {
-                Title = $"Install {item.Name}",
+                Title = LocalizationService.GetString("InstallGame", item.Name),
                 Maximizable = false,
                 DefaultMaximized = false,
                 Closable = true,
-                OkText = "Install",
+                OkText = LocalizationService.GetString("Install"),
                 Draggable = true,
                 Centered = true,
                 WrapClassName = "ant-modal-wrap-no-padding",
@@ -321,8 +322,8 @@
     async Task OnInstallFail(Data.Models.Game game)
     {
         var result = await ConfirmService.Show(
-            $"The installation for {game.Title} has failed. Retry download?",
-            "Installation Failed",
+            LocalizationService.GetString("InstallationFailedMessage", game.Title),
+            LocalizationService.GetString("InstallationFailed"),
             ConfirmButtons.RetryCancel,
             ConfirmIcon.Error
         );
@@ -376,11 +377,11 @@
             .Select(ps => ps.End.Value.Subtract(ps.Start.Value))
             .Sum(ts => ts.Ticks));
         if (totalTime.TotalMinutes < 1)
-            return "None";
+            return LocalizationService.GetString("None");
         else if (totalTime.TotalHours < 1)
-            return totalTime.TotalMinutes.ToString("0") + " minutes";
+            return LocalizationService.GetString("PlayTimeMinutes", totalTime.TotalMinutes.ToString("0"));
         else
-            return totalTime.TotalHours.ToString("0.##") + " hours";
+            return LocalizationService.GetString("PlayTimeHours", totalTime.TotalHours.ToString("0.##"));
     }
 
     string GetLastPlayed(Data.Models.Game game)
@@ -388,7 +389,7 @@
         var lastSession = game.PlaySessions.Where(ps => ps.End != null && ps.Start != null).OrderByDescending(ps => ps.End).FirstOrDefault();
 
         if (lastSession == null)
-            return "Never";
+            return LocalizationService.GetString("Never");
         else
             return lastSession.End.Value.ToRelativeDate();
     }

--- a/LANCommander.Launcher/UI/MainLayout.razor
+++ b/LANCommander.Launcher/UI/MainLayout.razor
@@ -15,6 +15,7 @@
 @inject IJSRuntime JS
 @inject ILogger<MainLayout> Logger
 @inject ImportManagerService ImportManagerService
+@inject LocalizationService LocalizationService
 
     <CustomWindow HeaderHeight="37">
         <HeaderExtraControlsLayout>
@@ -39,13 +40,13 @@
                             }
                             else if (ConnectionState.IsConnected)
                             {
-                                <Tooltip Title="Re-import library" MouseEnterDelay="0.5">
+                                <Tooltip Title="@LocalizationService.GetString("ReimportLibrary")" MouseEnterDelay="0.5">
                                     <Button Type="@ButtonType.Text" Icon="@IconType.Outline.Sync" OnClick="@ImportHandler.Import"/>
                                 </Tooltip>
                             }
                             else if (!string.IsNullOrEmpty(Settings.Authentication.AccessToken))
                             {
-                                <Tooltip Title="Reconnect to server" MouseEnterDelay="0.5">
+                                <Tooltip Title="@LocalizationService.GetString("ReconnectToServer")" MouseEnterDelay="0.5">
                                     <Button Type="@ButtonType.Text" Icon="@IconType.Outline.CloudSync" OnClick="Connect" Loading="@Connecting" Danger/>
                                 </Tooltip>
                             }
@@ -65,7 +66,7 @@
             </Space>
         </HeaderExtraControlsLayout>
         <WindowContent>
-            <ErrorHandler Title="Launcher Crashed">
+            <ErrorHandler Title="@LocalizationService.GetString("LauncherCrashed")">
                 <Body>
                     <AuthenticatedView NoAutoValidate="false">
                         <Authenticated>
@@ -89,7 +90,7 @@
                 </Body>
 
                 <Extra>
-                    <Button Type="ButtonType.Primary" OnClick="@(() => NavigationManager.NavigateTo("/", true))">View Library</Button>
+                    <Button Type="ButtonType.Primary" OnClick="@(() => NavigationManager.NavigateTo("/", true))">@LocalizationService.GetString("ViewLibrary")</Button>
                 </Extra>
             </ErrorHandler>
         </WindowContent>
@@ -111,36 +112,7 @@
 
     string RandomQuip = "";
 
-    string[] CrashQuips = new[]
-    {
-        "You Died.",
-        "Snake? SNAAAAAAKE!",
-        "WASTED",
-        "Major fracture detected",
-        "The past is a gaping hole. You try to run from it, but the more you run, the deeper, the darker, the bigger it gets.",
-        "Your town center has been destroyed",
-        "Your forces are under attack!",
-        "You have lost the lead",
-        "Terrorists Win",
-        "War... War never changes.",
-        "You have died of dysentery",
-        "You have failed to restore the books. The Ages are lost.",
-        "Player was splattered by a demon",
-        "Sure, blame it on your ISP",
-        "Baba is no more",
-        "Guests are complaining they are lost",
-        "The darkness has overcome you",
-        "Subject: Gordon Freeman. Status: Terminated",
-        "Mission failed: You were spotted.",
-        "Critical damage! Eject, eject!",
-        "Your minions are unhappy. They are leaving.",
-        "The Empire has triumphed",
-        "Your quest has ended in failure",
-        "You have been eaten by a grue",
-        "You no mess with Lo Wang!",
-        "Sam was killed. Serious carnage ensues.",
-        "Damn, those alien bastards are gonna pay for shooting up my ride"
-    };
+    string[] _crashQuips;
 
     protected override async Task OnInitializedAsync()
     {
@@ -169,9 +141,40 @@
             await ImportManagerService.RequestImport();
             await InvokeAsync(StateHasChanged);
         }
+        
+        _crashQuips = new[]
+        {
+            LocalizationService.GetString("CrashQuip_YouDied"),
+            LocalizationService.GetString("CrashQuip_Snake"),
+            LocalizationService.GetString("CrashQuip_Wasted"),
+            LocalizationService.GetString("CrashQuip_MajorFracture"),
+            LocalizationService.GetString("CrashQuip_PastIsGapingHole"),
+            LocalizationService.GetString("CrashQuip_TownCenterDestroyed"),
+            LocalizationService.GetString("CrashQuip_ForcesUnderAttack"),
+            LocalizationService.GetString("CrashQuip_LostLead"),
+            LocalizationService.GetString("CrashQuip_TerroristsWin"),
+            LocalizationService.GetString("CrashQuip_WarNeverChanges"),
+            LocalizationService.GetString("CrashQuip_DiedOfDysentery"),
+            LocalizationService.GetString("CrashQuip_FailedToRestoreBooks"),
+            LocalizationService.GetString("CrashQuip_PlayerSplattered"),
+            LocalizationService.GetString("CrashQuip_BlameISP"),
+            LocalizationService.GetString("CrashQuip_BabaNoMore"),
+            LocalizationService.GetString("CrashQuip_GuestsLost"),
+            LocalizationService.GetString("CrashQuip_DarknessOvercome"),
+            LocalizationService.GetString("CrashQuip_GordonFreemanTerminated"),
+            LocalizationService.GetString("CrashQuip_MissionFailedSpotted"),
+            LocalizationService.GetString("CrashQuip_CriticalDamageEject"),
+            LocalizationService.GetString("CrashQuip_MinionsUnhappy"),
+            LocalizationService.GetString("CrashQuip_EmpireTriumphed"),
+            LocalizationService.GetString("CrashQuip_QuestEndedFailure"),
+            LocalizationService.GetString("CrashQuip_EatenByGrue"),
+            LocalizationService.GetString("CrashQuip_NoMessWithLoWang"),
+            LocalizationService.GetString("CrashQuip_SamKilled"),
+            LocalizationService.GetString("CrashQuip_AlienBastardsPay")
+        };
 
-        var randIndex = new Random().Next(0, CrashQuips.Length - 1);
-        RandomQuip = CrashQuips[randIndex];
+        var randIndex = new Random().Next(0, _crashQuips.Length - 1);
+        RandomQuip = _crashQuips[randIndex];
     }
 
     public void Dispose()
@@ -199,7 +202,7 @@
     {
         await JS.InvokeVoidAsync("navigator.clipboard.writeText", ex.Message + "\n" + ex.StackTrace);
 
-        MessageService.Info("Error copied to clipboard!");
+        MessageService.Info(LocalizationService.GetString("ErrorCopiedToClipboard"));
     }
 
     async Task Connect()
@@ -219,7 +222,7 @@
             await AuthenticationService.Login();
             await ProfileService.DownloadProfileInfoAsync();
 
-            MessageService.Success("Back Online!");
+            MessageService.Success(LocalizationService.GetString("BackOnline"));
 
             ConnectionState.IsConnected = true;
             ConnectionState.OfflineModeEnabled = false;
@@ -236,11 +239,11 @@
             {
                 await ModalService.ConfirmAsync(new ConfirmOptions()
                 {
-                    Title = "Could Not Reconnect!",
+                    Title = LocalizationService.GetString("CouldNotReconnect"),
                     Icon = @<Icon Type="@IconType.Outline.ExclamationCircle"></Icon>,
-                    Content = "The LANCommander server could not be reached. Click stay offline and try later, or logout and enter your credentials.",
-                    OkText = "Logout",
-                    CancelText = "Stay Offline",
+                    Content = LocalizationService.GetString("CouldNotReconnectMessage"),
+                    OkText = LocalizationService.GetString("Logout"),
+                    CancelText = LocalizationService.GetString("StayOffline"),
                     Centered = true,
                     OnOk = async (e) =>
                     {

--- a/LANCommander.Launcher/UI/Settings/Index.razor
+++ b/LANCommander.Launcher/UI/Settings/Index.razor
@@ -1,51 +1,61 @@
 ﻿@page "/Settings"
+@using System.Globalization
 @using LANCommander.Launcher.Models
 @inject NavigationManager NavigationManager
 @inject UpdateService UpdateService
 @inject SDK.Client Client
 @inject IMessageService MessageService
 @inject ILogger<Index> Logger
+@inject LocalizationService LocalizationService
 
 <div style="flex-grow: 1">
     <PageHeader Title="Settings" OnBack="@(() => { NavigationManager.NavigateTo("/"); })" Style="padding-top: 48px">
         <PageHeaderExtra>
             <Flex Gap="FlexGap.Small" Justify="FlexJustify.End">
-                <Button OnClick="CheckForUpdates">Check for Updates</Button>
-                <Button OnClick="Save" Type="ButtonType.Primary">Save</Button>
+                            <Button OnClick="CheckForUpdates">@LocalizationService.GetString("CheckForUpdates")</Button>
+            <Button OnClick="Save" Type="ButtonType.Primary">@LocalizationService.GetString("Save")</Button>
             </Flex>
         </PageHeaderExtra>
     </PageHeader>
 
-    <Form Model="Settings" Layout="@FormLayout.Vertical" Style="padding: 0 24px">
-        <Divider Orientation="DividerOrientation.Left" Plain>Games</Divider>
-        <FormItem Label="Storage Paths">
+    <Form Model="_settings" Layout="@FormLayout.Vertical" Style="padding: 0 24px">
+        <Divider Orientation="DividerOrientation.Left" Plain>@LocalizationService.GetString("Games")</Divider>
+        <FormItem Label="@LocalizationService.GetString("StoragePaths")">
             <Flex Direction="FlexDirection.Vertical" Gap="FlexGap.Middle">
-                @foreach (var installDirectory in InstallDirectories)
+                @foreach (var installDirectory in _installDirectories)
                 {
                     <Flex Gap="FlexGap.Small">
                         <Input @bind-Value="installDirectory.Path"/>
-                        <Button OnClick="() => RemoveInstallDirectory(installDirectory)" Type="@ButtonType.Text" Danger Icon="@IconType.Outline.Close" Disabled="InstallDirectories.Count == 1"/>
+                        <Button OnClick="() => RemoveInstallDirectory(installDirectory)" Type="@ButtonType.Text" Danger Icon="@IconType.Outline.Close" Disabled="_installDirectories.Count == 1"/>
                     </Flex>
                 }
                 <Flex Justify="FlexJustify.End">
-                    <Button OnClick="AddInstallDirectory" Type="ButtonType.Primary">Add Path</Button>
+                    <Button OnClick="AddInstallDirectory" Type="ButtonType.Primary">@LocalizationService.GetString("AddPath")</Button>
                 </Flex>
             </Flex>
         </FormItem>
 
-        <Divider Orientation="DividerOrientation.Left" Plain>Media</Divider>
-        <FormItem Label="Storage Path">
+        <Divider Orientation="DividerOrientation.Left" Plain>@LocalizationService.GetString("Media")</Divider>
+        <FormItem Label="@LocalizationService.GetString("StoragePath")">
             <Input @bind-Value="@context.Media.StoragePath" />
         </FormItem>
+        
+        <Divider Orientation="DividerOrientation.Left" Plain>@LocalizationService.GetString("UI")</Divider>
+        <FormItem Label="@LocalizationService.GetString("Language")">
+            <Select @bind-Value="@context.Culture" TItem="string" TItemValue="string" DataSource="_supportedCultures">
+                <LabelTemplate Context="Value">@(CultureInfo.GetCultureInfo(Value).NativeName)</LabelTemplate>
+                <ItemTemplate Context="Value">@(CultureInfo.GetCultureInfo(Value).NativeName)</ItemTemplate>
+            </Select>
+        </FormItem>
 
-        <Divider Orientation="DividerOrientation.Left" Plain>Debug</Divider>
-        <FormItem Label="Enable Script Debugging">
+        <Divider Orientation="DividerOrientation.Left" Plain>@LocalizationService.GetString("Debug")</Divider>
+        <FormItem Label="@LocalizationService.GetString("EnableScriptDebugging")">
             <Switch @bind-Checked="@context.Debug.EnableScriptDebugging" />
         </FormItem>
-        <FormItem Label="Logging Path">
+        <FormItem Label="@LocalizationService.GetString("LoggingPath")">
             <Input @bind-Value="@context.Debug.LoggingPath" />
         </FormItem>
-        <FormItem Label="Logging Level">
+        <FormItem Label="@LocalizationService.GetString("LoggingLevel")">
             <Select @bind-Value="@context.Debug.LoggingLevel" TItem="LogLevel" TItemValue="LogLevel" DataSource="Enum.GetValues<LogLevel>()">
                 <LabelTemplate Context="Value">@Value.GetDisplayName()</LabelTemplate>
                 <ItemTemplate Context="Value">@Value.GetDisplayName()</ItemTemplate>
@@ -59,9 +69,24 @@
 </Flex>
 
 @code {
-    Settings Settings;
+    Settings _settings;
 
-    List<InstallDirectory> InstallDirectories = new List<InstallDirectory>();
+    List<InstallDirectory> _installDirectories = new();
+
+    string[] _supportedCultures = new[]
+    {
+        "en-US",
+        "de",
+        "es",
+        "fr",
+        "it",
+        "pt-BR",
+        "nl",
+        "ja",
+        "zh",
+        "ko",
+        "uk"
+    };
 
     internal class InstallDirectory
     {
@@ -77,11 +102,11 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Settings = SettingService.GetSettings();
+        _settings = SettingService.GetSettings();
 
-        foreach (var installDirectory in Settings.Games.InstallDirectories)
+        foreach (var installDirectory in _settings.Games.InstallDirectories)
         {
-            InstallDirectories.Add(new InstallDirectory(installDirectory));
+            _installDirectories.Add(new InstallDirectory(installDirectory));
         }
     }
 
@@ -89,18 +114,18 @@
     {
         try
         {
-            Settings.Games.InstallDirectories = InstallDirectories.Where(d => !String.IsNullOrWhiteSpace(d.Path)).Select(d => d.Path).ToArray();
+            _settings.Games.InstallDirectories = _installDirectories.Where(d => !String.IsNullOrWhiteSpace(d.Path)).Select(d => d.Path).ToArray();
 
-            SettingService.SaveSettings(Settings);
+            SettingService.SaveSettings(_settings);
 
-            Client.DefaultInstallDirectory = Settings.Games.InstallDirectories.First();
-            Client.Scripts.Debug = Settings.Debug.EnableScriptDebugging;
+            Client.DefaultInstallDirectory = _settings.Games.InstallDirectories.First();
+            Client.Scripts.Debug = _settings.Debug.EnableScriptDebugging;
 
-            MessageService.Success("Settings saved!");
+            MessageService.Success(LocalizationService.GetString("SettingsSaved"));
         }
         catch (Exception ex)
         {
-            MessageService.Error("An unknown error occurred.");
+            MessageService.Error(LocalizationService.GetString("AnUnknownErrorOccurred"));
             Logger.LogError(ex, "An unknown error occurred.");
         }
     }
@@ -112,18 +137,18 @@
         Logger.LogDebug("Checked for update: {UpdateVersion}", updateVersion.Version);
 
         if (updateVersion.Version == null)
-            MessageService.Success("You are on the latest version!");
+            MessageService.Success(LocalizationService.GetString("YouAreOnLatestVersion"));
     }
 
     async Task AddInstallDirectory()
     {
-        InstallDirectories.Add(new InstallDirectory(""));
+        _installDirectories.Add(new InstallDirectory(""));
 
         StateHasChanged();
     }
 
     async Task RemoveInstallDirectory(InstallDirectory installDirectory)
     {
-        InstallDirectories.Remove(installDirectory);
+        _installDirectories.Remove(installDirectory);
     }
 }


### PR DESCRIPTION
Adds localization across the launcher and includes English, German, Spanish, French, Italian, Japanese, Korean, Dutch, Portuguese, Ukranian, and Chinese. These localizations were generated by Claude 3.5 and need to be reviewed by a human for accuracy.