### PR TITLE
Fixing null ref error with versioned endpoint

### DIFF
--- a/LANCommander.Server/Endpoints/ArchivesEndpoints.cs
+++ b/LANCommander.Server/Endpoints/ArchivesEndpoints.cs
@@ -1,6 +1,6 @@
-using LANCommander.Server.Data.Models;
 using LANCommander.Server.Extensions;
 using LANCommander.Server.Services;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using System.IO.Compression;
 using ZiggyCreatures.Caching.Fusion;
@@ -20,27 +20,22 @@ public static class ArchivesEndpoints
         group.MapGet("/Contents/{id:guid}", ContentsAsync);
     }
 
-    internal static async Task<IResult> GetAsync(
+    internal static async Task<Results<Ok<ICollection<SDK.Models.Archive>>, UnauthorizedHttpResult>> GetAsync(
         [FromServices] ArchiveService archiveService)
-    {
-        var archives = await archiveService.GetAsync<SDK.Models.Archive>();
+            => TypedResults.Ok(await archiveService.GetAsync<SDK.Models.Archive>());
 
-        return TypedResults.Ok(archives);
-    }
-
-    internal static async Task<IResult> GetByIdAsync(
+    internal static async Task<Results<Ok<SDK.Models.Archive>, NotFound, UnauthorizedHttpResult>> GetByIdAsync(
         Guid id,
         [FromServices] ArchiveService archiveService)
     {
         var archive = await archiveService.GetAsync<SDK.Models.Archive>(id);
 
-        if (archive != null)
-            return TypedResults.Ok(archive);
-
-        return TypedResults.NotFound();
+        return archive is not null ?
+            TypedResults.Ok(archive) :
+            TypedResults.NotFound();
     }
 
-    internal static async Task<IResult> DownloadAsync(
+    internal static async Task<Results<FileStreamHttpResult, NotFound, UnauthorizedHttpResult>> DownloadAsync(
         Guid id,
         [FromServices] ArchiveService archiveService,
         [FromServices] ILoggerFactory loggerFactory)
@@ -49,7 +44,7 @@ public static class ArchivesEndpoints
 
         var archive = await archiveService.GetAsync(id);
 
-        if (archive == null)
+        if (archive is null)
         {
             logger.LogError("No archive found with ID {ArchiveId}", id);
             return TypedResults.NotFound();
@@ -59,7 +54,13 @@ public static class ArchivesEndpoints
 
         if (!File.Exists(filename))
         {
-            logger.LogError("Archive ({ArchiveId}) file not found at {FileName}", filename);
+            logger.LogError("Archive ({ArchiveId}) file not found at {FileName}", id, filename);
+            return TypedResults.NotFound();
+        }
+
+        if (archive.Game is null)
+        {
+            logger.LogError("Archive ({ArchiveId}) is missing associated game data", id);
             return TypedResults.NotFound();
         }
 
@@ -69,7 +70,7 @@ public static class ArchivesEndpoints
             $"{archive.Game.Title.SanitizeFilename()}.zip");
     }
 
-    internal static async Task<IResult> ByVersionAsync(
+    internal static async Task<Results<Ok<IEnumerable<ArchiveEntry>>, NotFound, UnauthorizedHttpResult>> ByVersionAsync(
         Guid gameId,
         string version,
         [FromServices] ArchiveService archiveService,
@@ -77,14 +78,18 @@ public static class ArchivesEndpoints
         [FromServices] ILoggerFactory loggerFactory)
     {
         var archive = await archiveService.FirstOrDefaultAsync(a => a.GameId == gameId && a.Version == version);
+        var logger = loggerFactory.CreateLogger("ArchivesApi");
 
-        if (archive == null)
+        if (archive is null)
+        {
+            logger.LogInformation("No archive found for game ID {GameId} with version {Version}", gameId, version);
             return TypedResults.NotFound();
+        }
 
         return await ContentsAsync(archive.Id, archiveService, cache, loggerFactory);
     }
 
-    internal static async Task<IResult> ContentsAsync(
+    internal static async Task<Results<Ok<IEnumerable<ArchiveEntry>>, NotFound, UnauthorizedHttpResult>> ContentsAsync(
         Guid id,
         [FromServices] ArchiveService archiveService,
         [FromServices] IFusionCache cache,
@@ -94,7 +99,7 @@ public static class ArchivesEndpoints
 
         var archive = await archiveService.GetAsync(id);
 
-        if (archive == null)
+        if (archive is null)
         {
             logger.LogError("No archive found with ID {ArchiveId}", id);
             return TypedResults.NotFound();
@@ -134,8 +139,12 @@ public static class ArchivesEndpoints
             tags: ["Archives", $"Archives/{id}", $"Games/{archive.GameId}/Archives"]);
 
         if (!entries.Any())
+        {
+            logger.LogInformation("No contents found for archive ID {ArchiveId}", id);
             return TypedResults.NotFound();
+        }
 
+        logger.LogInformation("Returning {EntryCount} entries for archive ID {ArchiveId}", entries.Count(), id);
         return TypedResults.Ok(entries);
     }
 }


### PR DESCRIPTION
The archive versioned endpoint passed in a null for the cache, which would result in this:



```

\[05:14:27 INF] Executed endpoint 'HTTP: GET /api/Archives/Contents/{gameId:guid}/{version} => ByVersionAsync'

\[05:14:27 ERR] An unhandled exception has occurred while executing the request.

System.NullReferenceException: Object reference not set to an instance of an object.

&nbsp;  at ZiggyCreatures.Caching.Fusion.FusionCacheExtMethods.GetOrSetAsync\[TValue](IFusionCache cache, String key, Func`2 factory, TimeSpan duration, IEnumerable`1 tags, CancellationToken token) in /\_/src/ZiggyCreatures.FusionCache/FusionCacheExtMethods\_FactoryNoCtx\_Async.cs:line 175

&nbsp;  at LANCommander.Server.Endpoints.ArchivesEndpoints.ContentsAsync(Guid id, ArchiveService archiveService, IFusionCache cache, ILoggerFactory loggerFactory)

&nbsp;  at LANCommander.Server.Endpoints.ArchivesEndpoints.ByVersionAsync(Guid gameId, String version, ArchiveService archiveService)

&nbsp;  at Microsoft.AspNetCore.Http.RequestDelegateFactory.ExecuteTaskResult\[T](Task`1 task, HttpContext httpContext)

&nbsp;  at Microsoft.AspNetCore.Routing.EndpointMiddleware.<Invoke>g\_\_AwaitRequestTask|7\_0(Endpoint endpoint, Task requestTask, ILogger logger)

&nbsp;  at Microsoft.AspNetCore.Authorization.AuthorizationMiddleware.Invoke(HttpContext context)

&nbsp;  at Microsoft.AspNetCore.Authentication.AuthenticationMiddleware.Invoke(HttpContext context)

&nbsp;  at Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddlewareImpl.<Invoke>g\_\_Awaited|10\_0(ExceptionHandlerMiddlewareImpl middleware, HttpContext context, Task task)

```



Fixed by resolving the services and passing them through.

