### PR TITLE
Adding SQLite database migration step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,3 +374,4 @@ LANCommander.Server/wwwroot/css/main.js
 .aspire
 LANCommander.Server/config/
 LANCommander.UI/wwwroot/
+LANCommander.Server/Data/

--- a/LANCommander.SDK/Migrations/FileSystemMigration.cs
+++ b/LANCommander.SDK/Migrations/FileSystemMigration.cs
@@ -1,0 +1,29 @@
+using LANCommander.SDK.Helpers;
+using Microsoft.Extensions.Logging;
+using Semver;
+using System;
+using System.Threading.Tasks;
+
+namespace LANCommander.SDK.Migrations;
+
+public abstract class FileSystemMigration(ILogger logger) : IMigration
+{
+    public abstract SemVersion Version { get; }
+
+    public Task ExecuteAsync()
+    {
+        logger.LogInformation("Starting file system migration: {MigrationType}", GetType().Name);
+
+        if (EnvironmentHelper.IsRunningInContainer() && !AppPaths.ConfigDirectoryIsMounted())
+            throw new PlatformNotSupportedException(
+                "Aborting migration to avoid data loss. Application is running in a container but config directory is not mounted.");
+
+        logger.LogInformation("File system migration pre-move checks passed.");
+
+        return ExecutePostMoveAsync();
+    }
+
+    public abstract Task ExecutePostMoveAsync();
+
+    
+}

--- a/LANCommander.SDK/Migrations/IMigration.cs
+++ b/LANCommander.SDK/Migrations/IMigration.cs
@@ -1,5 +1,5 @@
-using System.Threading.Tasks;
 using Semver;
+using System.Threading.Tasks;
 
 namespace LANCommander.SDK.Migrations;
 

--- a/LANCommander.SDK/Models/Settings/Settings.cs
+++ b/LANCommander.SDK/Models/Settings/Settings.cs
@@ -4,6 +4,7 @@ public class Settings
 {
     public const string DEFAULT_GAME_USERNAME = "Player";
     public const string SETTINGS_FILE_NAME = "Settings.yml";
+    public const string SQLITE_DEFAULT_DB_NAME = "LANCommander.db";
 
     public ArchiveSettings Archives { get; set; } = new();
     public AuthenticationSettings Authentication { get; set; } = new();

--- a/LANCommander.Server/Migrations/CombineSettingsYaml.cs
+++ b/LANCommander.Server/Migrations/CombineSettingsYaml.cs
@@ -1,7 +1,4 @@
 using System.Reflection;
-using LANCommander.SDK;
-using LANCommander.SDK.Abstractions;
-using LANCommander.SDK.Helpers;
 using LANCommander.SDK.Migrations;
 using LANCommander.Server.Settings.Enums;
 using LANCommander.Server.Settings.Models;
@@ -11,63 +8,88 @@ using YamlDotNet.Serialization.NamingConventions;
 
 namespace LANCommander.Server.Migrations;
 
-public class CombineSettingsYaml(SettingsProvider<Settings.Settings> settingsProvider) : IMigration
+public class CombineSettingsYaml(SettingsProvider<Settings.Settings> settingsProvider, ILogger<CombineSettingsYaml> logger) : FileSystemMigration(logger)
 {
-    public SemVersion Version => new(2, 0, 0);
-    
-    public async Task ExecuteAsync()
+    public override SemVersion Version => new(2, 0, 0);
+
+    public override async Task ExecutePostMoveAsync()
     {
-        if (EnvironmentHelper.IsRunningInContainer() && !AppPaths.ConfigDirectoryIsMounted())
-            throw new PlatformNotSupportedException(
-                "Aborting migration to avoid data loss. Application is running in a container but config directory is not mounted.");
-        
         var oldConfigDirectory = Directory.GetCurrentDirectory();
+        if (await TryMigrateSettingsFromLocation(oldConfigDirectory, SDK.Models.Settings.SETTINGS_FILE_NAME))
+        {
+            return;
+        }
+
+        if (await TryMigrateSettingsFromLocation(oldConfigDirectory, "Settings.Server.yml"))
+        {
+            return;
+        }
+
+        if (await TryMigrateSettingsFromLocation(Path.Combine(oldConfigDirectory, "config"), SDK.Models.Settings.SETTINGS_FILE_NAME))
+        {
+            return;
+        }
+
+        await TryMigrateSettingsFromLocation(Path.Combine(oldConfigDirectory, "config"), "Settings.Server.yml");
+    }
+
+    private async Task<bool> TryMigrateSettingsFromLocation(string oldConfigDirectory, string settingsFileName)
+    {
+        logger.LogInformation("Preparing to migrate settinngs from {OldConfigDirectory}", oldConfigDirectory);
 
         if (!IsDirectoryWritable(oldConfigDirectory))
         {
+            logger.LogInformation("Old config directory is not writable, attempting to locate settings in user profile.");
+
             var (company, product) = GetCompanyAndProduct();
             var userRoot = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        
+
             var appDataPath = Path.Combine(userRoot, company, product);
-        
+
             if (!Directory.Exists(appDataPath))
                 Directory.CreateDirectory(appDataPath);
 
             oldConfigDirectory = appDataPath;
+
+            logger.LogInformation("Located old config directory at {OldConfigDirectory}", oldConfigDirectory);
         }
-        
+
         var deserializer = new DeserializerBuilder()
             .WithNamingConvention(PascalCaseNamingConvention.Instance)
             .Build();
-        
-        var oldConfigPath = Path.Combine(oldConfigDirectory, SDK.Models.Settings.SETTINGS_FILE_NAME);
-        
-        if (!File.Exists(oldConfigPath))
-            oldConfigPath = Path.Combine(oldConfigDirectory, "Settings.Server.yml");
-        
-        if (File.Exists(oldConfigPath))
-        {
-            var convertedSettings = deserializer.Deserialize<ServerSettings>(await File.ReadAllTextAsync(oldConfigPath));
-            var oldSettings = deserializer.Deserialize<LegacySettings>(await File.ReadAllTextAsync(oldConfigPath));
 
-            convertedSettings.Http.Port = oldSettings.Port;
-            convertedSettings.Http.SSLPort = oldSettings.SSLPort;
-            convertedSettings.Http.CertificatePath = oldSettings.CertificatePath;
-            convertedSettings.Http.CertificatePassword = oldSettings.CertificatePassword;
-            convertedSettings.Http.UseSSL = oldSettings.UseSSL;
-            convertedSettings.Database.Provider = oldSettings.DatabaseProvider;
-            convertedSettings.Database.ConnectionString = oldSettings.DatabaseConnectionString;
-            convertedSettings.IGDB.ClientId = oldSettings.IGDBClientId;
-            convertedSettings.IGDB.ClientSecret = oldSettings.IGDBClientSecret;
-            convertedSettings.GameServers = oldSettings.Servers;
-            
-            settingsProvider.Update(s =>
-            {
-                s.Server = convertedSettings;
-            });
+        var oldConfigPath = Path.Combine(oldConfigDirectory, settingsFileName);
+
+        if (!File.Exists(oldConfigPath))
+        {
+            logger.LogInformation("No old settings file found at {OldConfigPath}", oldConfigPath);
+            return false;
         }
+
+        var convertedSettings = deserializer.Deserialize<ServerSettings>(await File.ReadAllTextAsync(oldConfigPath));
+        var oldSettings = deserializer.Deserialize<LegacySettings>(await File.ReadAllTextAsync(oldConfigPath));
+
+        convertedSettings.Http.Port = oldSettings.Port;
+        convertedSettings.Http.SSLPort = oldSettings.SSLPort;
+        convertedSettings.Http.CertificatePath = oldSettings.CertificatePath;
+        convertedSettings.Http.CertificatePassword = oldSettings.CertificatePassword;
+        convertedSettings.Http.UseSSL = oldSettings.UseSSL;
+        convertedSettings.Database.Provider = oldSettings.DatabaseProvider;
+        convertedSettings.Database.ConnectionString = oldSettings.DatabaseConnectionString;
+        convertedSettings.IGDB.ClientId = oldSettings.IGDBClientId;
+        convertedSettings.IGDB.ClientSecret = oldSettings.IGDBClientSecret;
+        convertedSettings.GameServers = oldSettings.Servers;
+
+        settingsProvider.Update(s =>
+        {
+            s.Server = convertedSettings;
+        });
+
+        logger.LogInformation("Successfully migrated settings from {OldConfigPath}", oldConfigPath);
+
+        return true;
     }
-    
+
     private bool IsDirectoryWritable(string path)
     {
         try
@@ -94,10 +116,10 @@ public class CombineSettingsYaml(SettingsProvider<Settings.Settings> settingsPro
     private (string? Company, string? Product) GetCompanyAndProduct()
     {
         var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-        
+
         var company = assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
         var product = assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product;
-        
+
         return (company, product);
     }
 

--- a/LANCommander.Server/Migrations/SqliteDatabaseLocation.cs
+++ b/LANCommander.Server/Migrations/SqliteDatabaseLocation.cs
@@ -1,0 +1,69 @@
+﻿using LANCommander.SDK;
+using LANCommander.SDK.Helpers;
+using LANCommander.SDK.Migrations;
+using Semver;
+
+namespace LANCommander.Server.Migrations;
+
+public class SqliteDatabaseLocation(ILogger<SqliteDatabaseLocation> logger, SettingsProvider<Settings.Settings> settingsProvider) : FileSystemMigration(logger)
+{
+    public override SemVersion Version => new(2, 0, 0);
+
+    public override async Task ExecutePostMoveAsync()
+    {
+        var baseDirectory = Directory.GetCurrentDirectory();
+
+        var oldConfigDirectory = Path.Combine(baseDirectory, "config");
+
+        var settings = settingsProvider.CurrentValue;
+
+        // Ensure we have settings available
+        if (settings is null)
+        {
+            logger.LogWarning("Settings are null, cannot perform SQLite database location migration.");
+            return;
+        }
+
+        // Only proceed if using SQLite
+        if (settings.Server.Database.Provider != Settings.Enums.DatabaseProvider.SQLite)
+        {
+            logger.LogInformation("Database provider is not SQLite, skipping database location migration.");
+            return;
+        }
+
+        var oldConnectionString = settings.Server.Database.ConnectionString;
+        // Ensure connection string is not empty
+        if (string.IsNullOrWhiteSpace(oldConnectionString))
+        {
+            logger.LogWarning("Database connection string is empty, cannot perform SQLite database location migration.");
+            return;
+        }
+
+        var csb = new Microsoft.Data.Sqlite.SqliteConnectionStringBuilder(oldConnectionString);
+        var location = csb.DataSource;
+        // Check if the file exists at the old location
+        if (!Path.Exists(location))
+        {
+            logger.LogWarning("SQLite database file does not exist at the specified location: {Location}", location);
+            return;
+        }
+
+        // Ensure the new config path exists
+        if (!Path.Exists(AppPaths.GetConfigPath()))
+        {
+            logger.LogWarning("Config path does not exist: {ConfigPath}", AppPaths.GetConfigPath());
+            return;
+        }
+
+        // Copy the database file to the new location and update the connection string
+        var newDatabasePath = Path.Combine(AppPaths.GetConfigPath(), Settings.Settings.SQLITE_DEFAULT_DB_NAME);
+        File.Copy(location, newDatabasePath);
+        csb.DataSource = newDatabasePath;
+        settingsProvider.Update(s =>
+        {
+            s.Server.Database.ConnectionString = csb.ConnectionString;
+        });
+
+        logger.LogInformation("SQLite database file moved to new location: {NewLocation} and settings have been updated.", newDatabasePath);
+    }
+}

--- a/LANCommander.Server/Startup/Migrations.cs
+++ b/LANCommander.Server/Startup/Migrations.cs
@@ -9,6 +9,7 @@ public static class Migrations
     public static WebApplicationBuilder AddMigrations(this WebApplicationBuilder builder)
     {
         builder.Services.AddScoped<IMigration, CombineSettingsYaml>();
+        builder.Services.AddScoped<IMigration, SqliteDatabaseLocation>();
         builder.Services.AddScoped<IMigration, EncapsulateUserData>();
 
         return builder;


### PR DESCRIPTION
Created a new abstraction for migrations that have to run against the file system, so that we don't need to do the check in each migration.

Adding the default DB name to the settings so it's got a const value.

Updated the Settings migrator to check a few more places
