### PR TITLE
Don't try to disconnect when there is no connection.

### DIFF
--- a/LANCommander.SDK/Rpc/Clients/RpcClient.Base.cs
+++ b/LANCommander.SDK/Rpc/Clients/RpcClient.Base.cs
@@ -44,7 +44,10 @@ internal partial class RpcSubscriber(ITokenProvider tokenProvider, ILogger<RpcSu
     {
         try
         {
-            await _connection.StopAsync();
+            if (_connection != null)
+            {
+                await _connection.StopAsync();
+            }
 
             return true;
         }


### PR DESCRIPTION
Added if condition: if there is no connection, than no need to perform disconnect. This line prevents crash when _connection is null.