### PR TITLE
Fix beacon discovery

### DIFF
--- a/LANCommander.Launcher/UI/Pages/Authenticate/Components/ServerSelector.razor
+++ b/LANCommander.Launcher/UI/Pages/Authenticate/Components/ServerSelector.razor
@@ -2,6 +2,7 @@
 @using LANCommander.SDK.Models
 @using ListItem = AntDesign.ListItem
 @namespace LANCommander.Launcher.UI
+@implements IDisposable
 @inject IConnectionClient ConnectionClient
 @inject BeaconClient BeaconClient
 @inject NavigationManager NavigationManager
@@ -105,7 +106,10 @@
         var discoveredServer = new DiscoveredServer(e.Message, e.EndPoint);
 
         if (DiscoveredServers.All(s => s.Address != discoveredServer.Address))
+        {
             DiscoveredServers.Add(discoveredServer);
+            InvokeAsync(StateHasChanged);
+        }
     }
 
     async Task SelectServer(Uri serverAddress)
@@ -162,6 +166,7 @@
 
     public void Dispose()
     {
+        BeaconClient.OnBeaconResponse -= OnBeaconResponse;
         DiscoveryToken?.Cancel();
         DiscoveryToken?.Dispose();
     }

--- a/LANCommander.SDK/Clients/BeaconClient.cs
+++ b/LANCommander.SDK/Clients/BeaconClient.cs
@@ -57,6 +57,8 @@ public class BeaconClient(
 
                 await probeClient.BindSocketAsync(port);
 
+                probeClient.OnBeaconResponse += (sender, args) => OnBeaconResponse?.Invoke(sender, args);
+
                 _probeClients.Add(probeClient);
             }
             catch

--- a/LANCommander.SDK/Clients/DiscoveryProbe.cs
+++ b/LANCommander.SDK/Clients/DiscoveryProbe.cs
@@ -25,9 +25,9 @@ public class DiscoveryProbe : IDisposable
     private readonly CancellationTokenSource _cancellationTokenSource;
     private readonly byte[] _probeId;
     private readonly NetworkInterface _networkInterface;
-    
+
     private byte[] _buffer = new byte[BufferSize];
-    
+
     public delegate void OnBeaconResponseHandler(object sender, BeaconResponseArgs e);
     public event OnBeaconResponseHandler OnBeaconResponse;
 
@@ -36,7 +36,7 @@ public class DiscoveryProbe : IDisposable
         _networkInterface = networkInterface;
         _udpClient = new UdpClient(0);
         _udpClient.EnableBroadcast = true;
-        
+
         _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
 
         _broadcastEndpoints = networkInterface.GetBroadcastAddresses().Select(ba => new IPEndPoint(ba, _port));
@@ -50,7 +50,7 @@ public class DiscoveryProbe : IDisposable
     public async Task SendAsync()
     {
         foreach (var endpoint in _broadcastEndpoints)
-            await _udpClient.SendAsync(_probeId, _probeId.Length, endpoint);
+            _socket.SendTo(_probeId, endpoint);
     }
 
     /// <summary>
@@ -72,6 +72,7 @@ public class DiscoveryProbe : IDisposable
 
         EndPoint fromEndpoint = new IPEndPoint(IPAddress.Any, 0);
 
+        _socket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, true);
         _socket.Bind(new IPEndPoint(addressInformation.Address, _port));
         _socket.BeginReceiveFrom(_buffer, 0, _buffer.Length, SocketFlags.None, ref fromEndpoint, ReceiveCallback, null);
     }
@@ -92,7 +93,7 @@ public class DiscoveryProbe : IDisposable
             {
                 byte[] response = new byte[receivedBytes];
                 Array.Copy(_buffer, response, receivedBytes);
-                
+
                 var message = Encoding.UTF8.GetString(response);
 
                 OnBeaconResponse?.Invoke(this, new BeaconResponseArgs

--- a/LANCommander.SDK/Clients/DiscoveryProbe.cs
+++ b/LANCommander.SDK/Clients/DiscoveryProbe.cs
@@ -83,18 +83,28 @@ public class DiscoveryProbe : IDisposable
     /// <param name="ar"></param>
     private void ReceiveCallback(IAsyncResult ar)
     {
+        EndPoint replyServer = new IPEndPoint(IPAddress.Any, 0);
+        int receivedBytes = 0;
+
         try
         {
-            EndPoint replyServer = new IPEndPoint(IPAddress.Any, 0);
+            receivedBytes = _socket.EndReceiveFrom(ar, ref replyServer);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Socket closed intentionally - do not re-arm
+            return;
+        }
+        catch (Exception)
+        {
+            // Socket error - still re-arm below
+        }
 
-            int receivedBytes = _socket.EndReceiveFrom(ar, ref replyServer);
-
-            if (receivedBytes > 0)
+        if (receivedBytes > 0)
+        {
+            try
             {
-                byte[] response = new byte[receivedBytes];
-                Array.Copy(_buffer, response, receivedBytes);
-
-                var message = Encoding.UTF8.GetString(response);
+                var message = Encoding.UTF8.GetString(_buffer, 0, receivedBytes);
 
                 OnBeaconResponse?.Invoke(this, new BeaconResponseArgs
                 {
@@ -102,17 +112,20 @@ public class DiscoveryProbe : IDisposable
                     Message = JsonSerializer.Deserialize<BeaconMessage>(message),
                 });
             }
+            catch (Exception)
+            {
+                // Non-JSON packet (e.g. broadcast loopback of own probe) - ignore, keep socket alive
+            }
+        }
 
+        try
+        {
             _buffer = new byte[BufferSize];
             _socket.BeginReceiveFrom(_buffer, 0, _buffer.Length, SocketFlags.None, ref replyServer, ReceiveCallback, null);
         }
         catch (ObjectDisposedException)
         {
-            // Socket closed
-        }
-        catch (Exception)
-        {
-            // Log error
+            // Socket was disposed between the receive and the re-arm
         }
     }
 


### PR DESCRIPTION
This should fix server discovery using the beacon system.

Made the discovery probe socket more resilient, before it was possible to kill the socket for good with malformed data.
- Invalid JSON data is ignored
- If an exception happens the socket will be re armed, otherwise discovery would stop working

 Fixed beacon responses not firing the proper events to notify the client.

Fixed a bug where an incoming beacon response was not updating the UI.
In some cases the client was actually discovering a server but was simply not presenting this information.