### PR TITLE
Corrected Local server engine tracking

### DIFF
--- a/LANCommander.Server.Services/ServerEngines/LocalServerEngine.cs
+++ b/LANCommander.Server.Services/ServerEngines/LocalServerEngine.cs
@@ -57,7 +57,7 @@ public class LocalServerEngine(
             var serverService = scope.ServiceProvider.GetRequiredService<ServerService>();
 
             var servers = await serverService.GetAsync(s =>
-                s.Engine == ServerEngine.Remote);
+                s.Engine == ServerEngine.Local);
 
             foreach (var server in servers)
             {


### PR DESCRIPTION
Servers using the Local engine were not working (anymore). The server wasn't throwing any logs.

Culprit was that the `RefreshTrackingAsync` (introduced in commit 4fc488d), which is called whenever LANCommander is started, or a Server is added or updated, didn't populate correctly with servers under the Local engine.
Additionally, Remote servers were therefore tracked by Local and Remote engines at the same time. Both engine would try to start the server.