### PR TITLE
Reduce Hangfire logging verbosity

### DIFF
--- a/LANCommander.Server/appsettings.json
+++ b/LANCommander.Server/appsettings.json
@@ -2,6 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
+      "Hangfire": "Warning",
       "Microsoft.AspNetCore": "Warning"
     }
   },


### PR DESCRIPTION
## Summary

- reduce Hangfire log output by setting its minimum level to `Warning`
- preserve the existing `Information` level for application logs

## Validation

- parsed `appsettings.json` successfully
- checked the diff for whitespace errors
