### PR TITLE
Fix stale JS bundle causing setModuleFunctions interop error

### DIFF
--- a/LANCommander.Server/UI/App.razor
+++ b/LANCommander.Server/UI/App.razor
@@ -34,7 +34,7 @@
     <script src="_content/AntDesign.Charts/ant-design-charts-blazor.js?v=@v"></script>
     <script src="_framework/blazor.web.js?v=@v"></script>
 
-    <script type="module" src="_content/LANCommander.UI/bundle.js?v=@v"></script>
+    <script type="module" src="@LANCommander.UI.UIAssets.BundleUrl"></script>
     <script src="_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js?v=@v"></script>
     <script src="_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js?v=@v"></script>
 

--- a/LANCommander.Server/UI/Pages/_Layout.cshtml
+++ b/LANCommander.Server/UI/Pages/_Layout.cshtml
@@ -36,7 +36,7 @@
         <script src="~/_content/AntDesign.Charts/ant-design-charts-blazor.js?v=@v"></script>
         <script src="~/_framework/blazor.server.js?v=@v"></script>
 
-        <script type="module" src="~/_content/LANCommander.UI/bundle.js?v=@v"></script>
+        <script type="module" src="@LANCommander.UI.UIAssets.BundleUrl"></script>
         <script src="~/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js?v=@v"></script>
         <script src="~/_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js?v=@v"></script>
 

--- a/LANCommander.UI/Components/CodeInput/CodeInput.razor
+++ b/LANCommander.UI/Components/CodeInput/CodeInput.razor
@@ -1,7 +1,9 @@
 @using BlazorMonaco.Editor
+@using Microsoft.Extensions.Logging
 @using Microsoft.JSInterop
 @namespace LANCommander.UI.Components
 @inject IJSRuntime JSRuntime
+@inject ILogger<CodeInput> Logger
 
 <StandaloneCodeEditor
     @ref="_editor"
@@ -83,7 +85,7 @@
         }, null);
 
         _module = await JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/LANCommander.UI/bundle.js");
+            "import", LANCommander.UI.UIAssets.BundleUrl);
 
         if (Language.Id == "powershell" && !_completionsRegistered)
         {
@@ -120,7 +122,17 @@
 
         _previousModuleFunctions = ModuleFunctions;
 
-        await _module.InvokeVoidAsync("setModuleFunctions", ModuleFunctions ?? []);
+        try
+        {
+            await _module.InvokeVoidAsync("setModuleFunctions", ModuleFunctions ?? []);
+        }
+        catch (JSException ex) when (ex.Message.Contains("setModuleFunctions", StringComparison.Ordinal))
+        {
+            // A cached/stale bundle predating this export would otherwise tear down the whole
+            // circuit. Module function completions are a nicety, so degrade instead of crashing.
+            Logger.LogWarning(ex,
+                "Unable to push PowerShell module functions to the editor. The loaded UI bundle may be out of date.");
+        }
     }
 
     public async Task LayoutAsync()

--- a/LANCommander.UI/Components/Loaders/ScriptLoader.razor
+++ b/LANCommander.UI/Components/Loaders/ScriptLoader.razor
@@ -1,5 +1,5 @@
 ﻿@namespace LANCommander.UI.Components
 
-<script type="module" src="/_content/LANCommander.UI/bundle.js"></script>
+<script type="module" src="@LANCommander.UI.UIAssets.BundleUrl"></script>
 <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"></script>
 <script src="/_content/PSD.Blazor.Components.MarkdownEditor/js/markdownEditor.js"></script>

--- a/LANCommander.UI/Components/MonacoCodeEditor/MonacoCodeEditor.cs
+++ b/LANCommander.UI/Components/MonacoCodeEditor/MonacoCodeEditor.cs
@@ -54,7 +54,7 @@ public class MonacoCodeEditor : StandaloneCodeEditor
         }, null);
 
         _module = await JSRuntime.InvokeAsync<IJSObjectReference>(
-            "import", "./_content/LANCommander.UI/bundle.js");
+            "import", UIAssets.BundleUrl);
 
         if (!_completionsRegistered)
         {

--- a/LANCommander.UI/Providers/ScriptProvider.cs
+++ b/LANCommander.UI/Providers/ScriptProvider.cs
@@ -5,7 +5,7 @@ namespace LANCommander.UI.Providers;
 
 public class ScriptProvider(IJSRuntime js)
 {
-    private const string ScriptAsset = "./_content/LANCommander.UI/bundle.js";
+    private static readonly string ScriptAsset = UIAssets.BundleUrl;
     
     private IJSObjectReference? _module;
 

--- a/LANCommander.UI/UIAssets.cs
+++ b/LANCommander.UI/UIAssets.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace LANCommander.UI;
+
+/// <summary>
+/// Centralizes the URL used to load the LANCommander.UI JavaScript bundle.
+/// </summary>
+/// <remarks>
+/// The bundle is loaded both by <c>&lt;script type="module"&gt;</c> tags and by dynamic
+/// <c>import()</c> calls from JS interop. The browser keys its module registry (and its HTTP cache)
+/// on the exact URL, so those URLs must match character for character. If they differ, the runtime
+/// ends up with two separate module records and interop can resolve against a stale bundle, which
+/// surfaces as "The value '&lt;function&gt;' is not a function".
+/// </remarks>
+public static class UIAssets
+{
+    private static readonly string Version =
+        typeof(UIAssets).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? typeof(UIAssets).Assembly.GetName().Version?.ToString()
+        ?? "0";
+
+    /// <summary>
+    /// Root-relative, cache-busted URL of the UI bundle. Use this everywhere the bundle is loaded.
+    /// </summary>
+    public static readonly string BundleUrl = $"/_content/LANCommander.UI/bundle.js?v={Uri.EscapeDataString(Version)}";
+}


### PR DESCRIPTION
## Problem

Editing a redistributable's script in `CodeInput` could throw:

```
Microsoft.JSInterop.JSException: The value 'setModuleFunctions' is not a function.
```

## Root cause

Blazor loads `bundle.js` through two different paths:
- Static `<script type="module" src="...bundle.js?v=@v">` tags (versioned)
- C# `IJSRuntime.InvokeAsync<IJSObjectReference>("import", "...bundle.js")` dynamic imports (previously **unversioned**)

Since these used different URL strings, the browser's module registry could resolve the dynamic import to a different (stale/cached) module instance than the one loaded by the script tag - one that predates a newer export like `setModuleFunctions`.

## Fix

- Added `LANCommander.UI/UIAssets.cs`, a small static helper exposing a single version-stamped `BundleUrl` (`/_content/LANCommander.UI/bundle.js?v={version}`).
- Updated all six bundle load sites (`CodeInput.razor`, `MonacoCodeEditor.cs`, `ScriptProvider.cs`, `ScriptLoader.razor`, `App.razor`, `_Layout.cshtml`) to use `UIAssets.BundleUrl`, so script tags and dynamic imports always agree on the exact URL.
- Added a narrowly-scoped fallback in `CodeInput.PushModuleFunctionsAsync()`: if the `setModuleFunctions` interop call still fails with this specific error, log a warning instead of crashing the Blazor circuit.

Note: the class is named `UIAssets` rather than `Assets` because `Assets` collides with ASP.NET Core's auto-generated static asset map (`ResourceAssetCollection`) in newer .NET versions.