### PR TITLE
fix(scripting): harden package job execution

### DIFF
--- a/LANCommander.SDK/Clients/ScriptClient.Games.cs
+++ b/LANCommander.SDK/Clients/ScriptClient.Games.cs
@@ -48,7 +48,7 @@ public partial class ScriptClient
                             script.AddVariable(customField.Name, customField.Value);
                         }
                     }
-                    
+
                     script.UseWorkingDirectory(installDirectory);
                     script.UseFile(path);
 
@@ -114,7 +114,7 @@ public partial class ScriptClient
                     script.AddVariable("GameManifest", manifest);
                     script.AddVariable("DefaultInstallDirectory", settingsProvider.CurrentValue.Games.InstallDirectories.FirstOrDefault());
                     script.AddVariable("ServerAddress", connectionClient.GetServerAddress());
-                    
+
                     if (manifest.CustomFields != null && manifest.CustomFields.Any())
                     {
                         foreach (var customField in manifest.CustomFields)
@@ -122,7 +122,7 @@ public partial class ScriptClient
                             script.AddVariable(customField.Name, customField.Value);
                         }
                     }
-                    
+
                     script.UseWorkingDirectory(installDirectory);
                     script.UseFile(path);
 
@@ -190,7 +190,7 @@ public partial class ScriptClient
                     script.AddVariable("DefaultInstallDirectory", settingsProvider.CurrentValue.Games.InstallDirectories.FirstOrDefault());
                     script.AddVariable("ServerAddress", connectionClient.GetServerAddress());
                     script.AddVariable("PlayerAlias", playerAlias);
-                    
+
                     if (manifest.CustomFields != null && manifest.CustomFields.Any())
                     {
                         foreach (var customField in manifest.CustomFields)
@@ -198,7 +198,7 @@ public partial class ScriptClient
                             script.AddVariable(customField.Name, customField.Value);
                         }
                     }
-                    
+
                     script.UseWorkingDirectory(installDirectory);
                     script.UseFile(path);
 
@@ -266,7 +266,7 @@ public partial class ScriptClient
                     script.AddVariable("DefaultInstallDirectory", settingsProvider.CurrentValue.Games.InstallDirectories.FirstOrDefault());
                     script.AddVariable("ServerAddress", connectionClient.GetServerAddress());
                     script.AddVariable("PlayerAlias", GameClient.GetPlayerAlias(installDirectory, gameId));
-                    
+
                     if (manifest.CustomFields != null && manifest.CustomFields.Any())
                     {
                         foreach (var customField in manifest.CustomFields)
@@ -274,7 +274,7 @@ public partial class ScriptClient
                             script.AddVariable(customField.Name, customField.Value);
                         }
                     }
-                    
+
                     script.UseWorkingDirectory(installDirectory);
                     script.UseFile(path);
 
@@ -353,7 +353,7 @@ public partial class ScriptClient
                     script.AddVariable("ServerAddress", connectionClient.GetServerAddress());
                     script.AddVariable("OldPlayerAlias", oldName);
                     script.AddVariable("NewPlayerAlias", newName);
-                    
+
                     if (manifest.CustomFields != null && manifest.CustomFields.Any())
                     {
                         foreach (var customField in manifest.CustomFields)
@@ -434,7 +434,7 @@ public partial class ScriptClient
                     script.AddVariable("DefaultInstallDirectory", settingsProvider.CurrentValue.Games.InstallDirectories.FirstOrDefault());
                     script.AddVariable("ServerAddress", connectionClient.GetServerAddress());
                     script.AddVariable("AllocatedKey", key);
-                    
+
                     if (manifest.CustomFields != null && manifest.CustomFields.Any())
                     {
                         foreach (var customField in manifest.CustomFields)
@@ -442,7 +442,7 @@ public partial class ScriptClient
                             script.AddVariable(customField.Name, customField.Value);
                         }
                     }
-                    
+
                     script.UseWorkingDirectory(installDirectory);
                     script.UseFile(path);
 
@@ -486,43 +486,38 @@ public partial class ScriptClient
         return result;
     }
 
-    public async Task<Package> Game_RunPackageScriptAsync(Script packageScript, Game game, string latestArchivePath = null)
+    public async Task<Package?> RunPackageScriptAsync(Script packageScript, Game game, string? latestArchivePath = null)
     {
         try
         {
-            using (var op = logger.BeginOperation("Executing game package script"))
+            using var op = logger.BeginOperation("Executing game package script");
+            var script = powerShellScriptFactory.Create(Enums.ScriptType.Package);
+
+            script.AddVariable("Game", game);
+
+            if (!string.IsNullOrEmpty(latestArchivePath))
+                script.AddVariable("LatestArchivePath", latestArchivePath);
+
+            script.UseInline(packageScript.Contents);
+
+            op
+                .Enrich("GameId", game.Id)
+                .Enrich("GameTitle", game.Title)
+                .Enrich("ScriptId", packageScript.Id)
+                .Enrich("ScriptName", packageScript.Name);
+
+            if (Debug)
             {
-                var script = powerShellScriptFactory.Create(Enums.ScriptType.Package);
-
-                script.AddVariable("Game", game);
-
-                if (!string.IsNullOrEmpty(latestArchivePath))
-                    script.AddVariable("LatestArchivePath", latestArchivePath);
-
-                script.UseInline(packageScript.Contents);
-                
-                try
-                {
-                    op
-                        .Enrich("GameId", game.Id)
-                        .Enrich("GameTitle", game.Title)
-                        .Enrich("ScriptId", packageScript.Id)
-                        .Enrich("ScriptName", packageScript.Name);
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, "Could not enrich logs");
-                }
-                
-                if (Debug)
-                    script.EnableDebug();
-
-                return await script.ExecuteAsync<Package>();
+                logger.LogInformation("Debugging is enabled for the package script ({ScriptName}) for game {GameTitle}", packageScript.Name, game.Title);
+                script.EnableDebug();
             }
+
+            logger.LogInformation("Running package script ({ScriptName}) for game {GameTitle}", packageScript.Name, game.Title);
+            return await script.ExecuteAsync<Package>();
         }
         catch (Exception ex)
         {
-            logger?.LogError(ex, "Could not execute game package script");
+            logger.LogError(ex, "Failed to run package script ({ScriptName}) for game {GameTitle}", packageScript.Name, game.Title);
         }
 
         return null;

--- a/LANCommander.SDK/LANCommander.SDK.csproj
+++ b/LANCommander.SDK/LANCommander.SDK.csproj
@@ -13,6 +13,7 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>lancommander</PackageTags>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>

--- a/LANCommander.SDK/PowerShell/PowerShellScript.cs
+++ b/LANCommander.SDK/PowerShell/PowerShellScript.cs
@@ -21,17 +21,15 @@ namespace LANCommander.SDK.PowerShell
     public class PowerShellScript
     {
         public ScriptType Type { get; private set; }
-        private string Contents { get; set; }           = "";
-        public string WorkingDirectory { get; private set; }   = "";
-        private bool ShellExecute { get; set; }         = false;
-        public bool RunAsAdmin { get; private set; }       = false;
-        private bool IgnoreWow64 { get; set; }          = false;
-        private bool Debug { get; set; }                = false;
+        private string Contents { get; set; } = "";
+        public string WorkingDirectory { get; private set; } = "";
+        private bool ShellExecute { get; set; } = false;
+        public bool RunAsAdmin { get; private set; } = false;
+        private bool IgnoreWow64 { get; set; } = false;
+        private bool Debug { get; set; } = false;
         public PowerShellVariableList Variables { get; private set; }
         public Dictionary<string, string> Arguments { get; private set; }
 
-        private TaskCompletionSource<string> Input { get; set; }
-        
         private IntPtr _wow64 = IntPtr.Zero;
         private readonly IServiceProvider ServiceProvider;
         private readonly ILogger<PowerShellScript> Logger;
@@ -52,19 +50,18 @@ namespace LANCommander.SDK.PowerShell
             ScriptType type,
             IOptions<Settings> settings)
         {
-            
             Type = type;
-            Variables = new PowerShellVariableList();
-            Arguments = new Dictionary<string, string>();
-            
+            Variables = [];
+            Arguments = [];
+
             // Instantiate a new scope
             ServiceProvider = serviceProvider;
             Logger = ServiceProvider.GetRequiredService<ILogger<PowerShellScript>>();
 
             var settingsProvider = ServiceProvider.GetService<ISettingsProvider>();
-            
+
             Debug = settingsProvider.CurrentValue.Debug.EnableScriptDebugging;
-            
+
             IgnoreWow64Redirection();
         }
 
@@ -166,7 +163,7 @@ namespace LANCommander.SDK.PowerShell
         private bool RequiresAdmin()
         {
             var pattern = @"^#(\s?Requires\s?Admin|Requires -RunAsAdministrator)\s*";
-            
+
             return Regex.IsMatch(Contents, pattern);
         }
 
@@ -219,167 +216,140 @@ namespace LANCommander.SDK.PowerShell
             }
         }
 
-        public async Task<T> ExecuteAsync<T>()
+        public async Task<T?> ExecuteAsync<T>()
         {
-            T result = default;
+            T? result = default;
 
             DisableWow64Redirection();
 
-            using (Runspace runspace = OpenRunspace())
-            {
-                var modulesPath = AppPaths.GetConfigPath("Modules");
-                
-                if (Directory.Exists(modulesPath))
-                {
-                    foreach (var moduleDirectory in Directory.GetDirectories(modulesPath))
-                    {
-                        try
-                        {
-                            using var import = System.Management.Automation.PowerShell.Create();
-                            
-                            import.Runspace = runspace;
-                                
-                            import.AddCommand("Import-Module")
-                                .AddParameter("Name", moduleDirectory)
-                                .AddParameter("ErrorAction", "Stop");
-                                
-                            import.Invoke();
+            using Runspace runspace = OpenRunspace();
 
-                            if (import.HadErrors)
-                                foreach (var error in import.Streams.Error)
-                                    Logger.LogWarning("Failed to load module {ModuleDirectory}: {ErrorMessage}", moduleDirectory, error.Exception?.Message);
-                        }
-                        catch (Exception ex)
+            var modulesPath = AppPaths.GetConfigPath("Modules");
+
+            if (Directory.Exists(modulesPath))
+            {
+                foreach (var moduleDirectory in Directory.GetDirectories(modulesPath))
+                {
+                    ImportModuleIntoRunspace(runspace, moduleDirectory);
+                }
+            }
+
+            // Ensure TLS 1.2 is available for web requests (GitHub, etc.)
+            using (var tls = System.Management.Automation.PowerShell.Create())
+            {
+                Logger.LogInformation("Ensuring TLS 1.2 is enabled for PowerShell runspace");
+                tls.Runspace = runspace;
+                tls.AddScript("[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12");
+                tls.Invoke();
+            }
+
+            runspace.SessionStateProxy.Path.SetLocation(WorkingDirectory);
+
+            foreach (var variable in Variables)
+            {
+                Logger.LogInformation("Setting PowerShell variable ${VariableName} = {VariableValue}", variable.Name, variable.Value);
+                runspace.SessionStateProxy.SetVariable(variable.Name, variable.Value);
+            }
+
+            runspace.SessionStateProxy.SetVariable("Logo", Logo);
+            runspace.SessionStateProxy.SetVariable("ScriptType", Type);
+            runspace.SessionStateProxy.SetVariable("WorkingDirectory", WorkingDirectory);
+
+            // Store services in session state for cmdlets to access
+            var settingsProvider = ServiceProvider.GetService<ISettingsProvider>();
+            if (settingsProvider is not null)
+            {
+                runspace.SessionStateProxy.SetVariable("LANCommander.SDK.ISettingsProvider", settingsProvider);
+            }
+
+            var apiRequestFactory = ServiceProvider.GetService<ApiRequestFactory>();
+            if (apiRequestFactory is not null)
+            {
+                runspace.SessionStateProxy.SetVariable("LANCommander.SDK.ApiRequestFactory", apiRequestFactory);
+            }
+
+            // Logger will be created when first cmdlet runs and sets host UI in session state (see AsyncCmdlet)
+
+            Context = System.Management.Automation.PowerShell.Create();
+
+            Context.Runspace = runspace;
+
+            DebugContext = new PowerShellDebugContext(Context);
+
+            await DebugAsync(async dbg =>
+            {
+                await dbg.StartAsync(DebugContext);
+            });
+
+            Context.AddScript("Write-Host $Logo");
+            Context.AddScript(Contents);
+
+            Context.Streams.Information.DataAdded += Information_DataAdded;
+            Context.Streams.Verbose.DataAdded += Verbose_DataAdded;
+            Context.Streams.Debug.DataAdded += Debug_DataAdded;
+            Context.Streams.Warning.DataAdded += Warning_DataAdded;
+            Context.Streams.Error.DataAdded += Error_DataAdded;
+
+            if (Debug)
+            {
+                AddDebugHeader();
+            }
+
+            try
+            {
+                Logger.LogInformation("Executing PowerShell script of type {ScriptType}", Type);
+                var results = await Context.InvokeAsync();
+
+                if (Context.HadErrors)
+                {
+                    foreach (var error in Context.Streams.Error)
+                    {
+                        Logger.LogError("Script error: {InvocationName} : {ErrorMessage}", error.InvocationInfo?.InvocationName, error.Exception?.Message);
+
+                        await DebugAsync(async dbg =>
                         {
-                            Logger.LogWarning(ex, "Failed to load module {ModuleDirectory}", moduleDirectory);
-                        }
+                            await dbg.OutputAsync(DebugContext, LogLevel.Error, "{InvocationName} : {ErrorMessage}", error.InvocationInfo?.InvocationName, error.Exception?.Message);
+                        });
                     }
                 }
 
-                // Ensure TLS 1.2 is available for web requests (GitHub, etc.)
-                using (var tls = System.Management.Automation.PowerShell.Create())
+                var returnValue = Context.Runspace.SessionStateProxy.PSVariable.GetValue("Return");
+
+                if (returnValue is null && results is { Count: > 0 })
+                    returnValue = results[^1];
+
+                if (returnValue is not null)
                 {
-                    tls.Runspace = runspace;
-                    tls.AddScript("[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12");
-                    tls.Invoke();
+                    result = ConvertResult<T>(returnValue);
+
+                    if (result is null)
+                        Logger.LogWarning("Script returned a value but it could not be converted to {ExpectedType}", typeof(T).Name);
                 }
-
-                runspace.SessionStateProxy.Path.SetLocation(WorkingDirectory);
-
-                foreach (var variable in Variables)
+                else
                 {
-                    runspace.SessionStateProxy.SetVariable(variable.Name, variable.Value);
+                    Logger.LogWarning("Script did not return a value via $Return or the pipeline");
                 }
-
-                runspace.SessionStateProxy.SetVariable("Logo", Logo);
-                runspace.SessionStateProxy.SetVariable("ScriptType", Type);
-                runspace.SessionStateProxy.SetVariable("WorkingDirectory", WorkingDirectory);
-                
-                // Store services in session state for cmdlets to access
-                var settingsProvider = ServiceProvider.GetService<ISettingsProvider>();
-                if (settingsProvider != null)
-                {
-                    runspace.SessionStateProxy.SetVariable("LANCommander.SDK.ISettingsProvider", settingsProvider);
-                }
-
-                var apiRequestFactory = ServiceProvider.GetService<ApiRequestFactory>();
-                if (apiRequestFactory != null)
-                {
-                    runspace.SessionStateProxy.SetVariable("LANCommander.SDK.ApiRequestFactory", apiRequestFactory);
-                }
-                
-                // Logger will be created when first cmdlet runs and sets host UI in session state (see AsyncCmdlet)
-                
-                Context = System.Management.Automation.PowerShell.Create();
-
-                Context.Runspace = runspace;
-
-                DebugContext = new PowerShellDebugContext(Context);
-
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Could not execute script");
+            }
+            finally
+            {
                 await DebugAsync(async dbg =>
                 {
-                    await dbg.StartAsync(DebugContext);
+                    await dbg.EndAsync(DebugContext);
                 });
 
-                Context.AddScript("Write-Host $Logo");
-                Context.AddScript(Contents);
-
-                Context.Streams.Information.DataAdded += Information_DataAdded;
-                Context.Streams.Verbose.DataAdded += Verbose_DataAdded;
-                Context.Streams.Debug.DataAdded += Debug_DataAdded;
-                Context.Streams.Warning.DataAdded += Warning_DataAdded;
-                Context.Streams.Error.DataAdded += Error_DataAdded;
-
-                if (Debug) {
-                    Context.AddScript("Write-Host '--------- DEBUG ---------'");
-                    Context.AddScript("Write-Host \"Script Type: $ScriptType\"");
-                    Context.AddScript("Write-Host \"Working Directory: $WorkingDirectory\"");
-                    Context.AddScript("Write-Host 'Variables:'");
-
-                    foreach (var variable in Variables)
-                    {
-                        Context.AddScript($"Write-Host '    ${variable.Name}'");
-                    }
-
-                    Context.AddScript("Write-Host ''");
-                    Context.AddScript("Write-Host 'Enter \"exit\" to continue'");
-                }
-
-                try
-                {
-                    var results = await Context.InvokeAsync();
-
-                    if (Context.HadErrors)
-                    {
-                        foreach (var error in Context.Streams.Error)
-                        {
-                            Logger.LogError("Script error: {InvocationName} : {ErrorMessage}", error.InvocationInfo?.InvocationName, error.Exception?.Message);
-
-                            await DebugAsync(async dbg =>
-                            {
-                                await dbg.OutputAsync(DebugContext, LogLevel.Error, "{InvocationName} : {ErrorMessage}", error.InvocationInfo?.InvocationName, error.Exception?.Message);
-                            });
-                        }
-                    }
-
-                    var returnValue = Context.Runspace.SessionStateProxy.PSVariable.GetValue("Return");
-
-                    if (returnValue == null && results != null && results.Count > 0)
-                        returnValue = results[results.Count - 1];
-
-                    if (returnValue != null)
-                    {
-                        result = ConvertResult<T>(returnValue);
-
-                        if (result == null)
-                            Logger.LogWarning("Script returned a value but it could not be converted to {ExpectedType}", typeof(T).Name);
-                    }
-                    else
-                    {
-                        Logger.LogWarning("Script did not return a value via $Return or the pipeline");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogError(ex, "Could not execute script");
-                }
-                finally
+                if (Debug)
                 {
                     await DebugAsync(async dbg =>
                     {
-                        await dbg.EndAsync(DebugContext);
+                        await dbg.BreakAsync(DebugContext);
                     });
-
-                    if (Debug)
-                    {
-                        await DebugAsync(async dbg =>
-                        {
-                            await dbg.BreakAsync(DebugContext);
-                        });
-                    }
-
-                    Context.Dispose();
                 }
+
+                Context.Dispose();
             }
 
             RevertWow64Redirection();
@@ -387,7 +357,48 @@ namespace LANCommander.SDK.PowerShell
             return result;
         }
 
-        private static T ConvertResult<T>(object value)
+        private void AddDebugHeader()
+        {
+            Context.AddScript("Write-Host '--------- DEBUG ---------'");
+            Context.AddScript("Write-Host \"Script Type: $ScriptType\"");
+            Context.AddScript("Write-Host \"Working Directory: $WorkingDirectory\"");
+            Context.AddScript("Write-Host 'Variables:'");
+
+            foreach (var variable in Variables)
+            {
+                Context.AddScript($"Write-Host '    ${variable.Name}'");
+            }
+
+            Context.AddScript("Write-Host ''");
+            Context.AddScript("Write-Host 'Enter \"exit\" to continue'");
+        }
+
+        private void ImportModuleIntoRunspace(Runspace runspace, string moduleDirectory)
+        {
+            Logger.LogInformation("Importing PowerShell module from {ModuleDirectory}", moduleDirectory);
+            try
+            {
+                using var import = System.Management.Automation.PowerShell.Create();
+
+                import.Runspace = runspace;
+
+                import.AddCommand("Import-Module")
+                    .AddParameter("Name", moduleDirectory)
+                    .AddParameter("ErrorAction", "Stop");
+
+                import.Invoke();
+
+                if (import.HadErrors)
+                    foreach (var error in import.Streams.Error)
+                        Logger.LogWarning("Failed to load module {ModuleDirectory}: {ErrorMessage}", moduleDirectory, error.Exception?.Message);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Failed to load module {ModuleDirectory}", moduleDirectory);
+            }
+        }
+
+        private static T? ConvertResult<T>(object value)
         {
             // Unwrap PSObject wrapper
             var psObj = value as PSObject;
@@ -439,8 +450,7 @@ namespace LANCommander.SDK.PowerShell
 
         private async Task DebugAsync(Func<IScriptDebugger, Task> action)
         {
-            if (Debuggers == null)
-                Debuggers = ServiceProvider.GetServices<IScriptDebugger>();
+            Debuggers ??= ServiceProvider.GetServices<IScriptDebugger>();
 
             foreach (var debugger in Debuggers)
             {
@@ -448,8 +458,11 @@ namespace LANCommander.SDK.PowerShell
             }
         }
 
-        private async void Error_DataAdded(object sender, DataAddedEventArgs e)
+        private async void Error_DataAdded(object? sender, DataAddedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var record = ((PSDataCollection<ErrorRecord>)sender)[e.Index];
 
             await DebugAsync(async dbg =>
@@ -459,18 +472,24 @@ namespace LANCommander.SDK.PowerShell
             });
         }
 
-        private async void Warning_DataAdded(object sender, DataAddedEventArgs e)
+        private async void Warning_DataAdded(object? sender, DataAddedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var record = ((PSDataCollection<WarningRecord>)sender)[e.Index];
-            
+
             await DebugAsync(async dbg =>
             {
                 await dbg.OutputAsync(DebugContext, LogLevel.Warning, record.Message);
             });
         }
 
-        private async void Debug_DataAdded(object sender, DataAddedEventArgs e)
+        private async void Debug_DataAdded(object? sender, DataAddedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var record = ((PSDataCollection<DebugRecord>)sender)[e.Index];
 
             await DebugAsync(async dbg =>
@@ -479,8 +498,11 @@ namespace LANCommander.SDK.PowerShell
             });
         }
 
-        private async void Verbose_DataAdded(object sender, DataAddedEventArgs e)
+        private async void Verbose_DataAdded(object? sender, DataAddedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var record = ((PSDataCollection<VerboseRecord>)sender)[e.Index];
 
             await DebugAsync(async dbg =>
@@ -489,10 +511,13 @@ namespace LANCommander.SDK.PowerShell
             });
         }
 
-        private async void Information_DataAdded(object sender, DataAddedEventArgs e)
+        private async void Information_DataAdded(object? sender, DataAddedEventArgs e)
         {
+            if (sender is null)
+                return;
+
             var record = ((PSDataCollection<InformationRecord>)sender)[e.Index];
-            
+
             await DebugAsync(async dbg =>
             {
                 await dbg.OutputAsync(DebugContext, LogLevel.Information, (record.MessageData as HostInformationMessage).Message);

--- a/LANCommander.Server.Services/GameService.cs
+++ b/LANCommander.Server.Services/GameService.cs
@@ -1,4 +1,4 @@
-﻿using System.IO.Compression;
+using System.IO.Compression;
 using AutoMapper;
 using LANCommander.Server.Data;
 using LANCommander.Server.Data.Models;
@@ -297,12 +297,12 @@ namespace LANCommander.Server.Services
                 .Include(g => g.Scripts)
                 .GetAsync(id);
             
-            logger?.LogInformation("Packaging game {GameTitle}", game.Title);
+            logger.LogInformation("Packaging game {GameTitle}", game.Title);
 
             var latestArchive = game.Archives?.OrderByDescending(a => a.CreatedOn).FirstOrDefault();
             var storageLocation = await storageLocationService.GetOrDefaultAsync(latestArchive?.StorageLocationId, StorageLocationType.Archive);
 
-            string latestArchivePath = null;
+            string? latestArchivePath = null;
             if (latestArchive != null)
                 latestArchivePath = await archiveService.GetArchiveFileLocationAsync(latestArchive);
 
@@ -310,22 +310,23 @@ namespace LANCommander.Server.Services
             {
                 foreach (var script in game.Scripts.Where(s => s.Type == ScriptType.Package))
                 {
-                    var package = await scriptClient.Game_RunPackageScriptAsync(mapper.Map<SDK.Models.Script>(script), mapper.Map<SDK.Models.Game>(game), latestArchivePath);
+                    logger.LogInformation("Running script {Name} for game {GameTitle}", script.Name, game.Title);
+                    var package = await scriptClient.RunPackageScriptAsync(mapper.Map<SDK.Models.Script>(script), mapper.Map<SDK.Models.Game>(game), latestArchivePath);
 
-                    if (package == null)
+                    if (package is null)
                     {
-                        var message = $"Could not package game {game.Title}, the package script did not return a result";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger.LogError("Could not package game '{Title} ({Id})', the package script did not return a result", game.Title, game.Id);
+                        return;
                     }
 
-                    if (String.IsNullOrWhiteSpace(package.Path) || !Directory.Exists(package.Path))
+                    if (string.IsNullOrWhiteSpace(package.Path) || !Directory.Exists(package.Path))
                     {
-                        var message = $"Could not package game {game.Title}, the path {package.Path} could not be found";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger.LogError("Could not package game '{Title} ({Id})', the path {Path} could not be found", game.Title, game.Id, package.Path);
+                        return;
                     }
-                    
+
+                    logger.LogInformation("New archive for game {GameTitle} will be created with version number {GameVersion}", game.Title, package.Version);
+
                     var archive = new Archive
                     {
                         Version = package.Version,
@@ -343,14 +344,13 @@ namespace LANCommander.Server.Services
 
                     await archiveService.RecalculateFileSizeArchiveAsync(archive);
 
-                    logger?.LogInformation("Successfully packaged {GameTitle} and created new archive with version number {GameVersion}", game.Title, archive.Version);
+                    logger.LogInformation("Successfully packaged {GameTitle} and created new archive with version number {GameVersion}", game.Title, archive.Version);
                 }
             }
             else
             {
-                var message = $"Could not package game {game.Title}, no packaging scripts are defined";
-                logger?.LogWarning(message);
-                throw new Exception(message);
+                logger.LogWarning("Could not package game '{GameTitle}', no packaging scripts are defined", game.Title);
+                return;
             }
         }
     }

--- a/LANCommander.Server.Services/RedistributableService.cs
+++ b/LANCommander.Server.Services/RedistributableService.cs
@@ -142,16 +142,14 @@ namespace LANCommander.Server.Services
 
                     if (package == null)
                     {
-                        var message = $"Could not package redistributable {redistributable.Name}, the package script did not return a result";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger?.LogError("Could not package redistributable '{RedistributableName}', the package script did not return a result", redistributable.Name);
+                        return;
                     }
 
                     if (String.IsNullOrWhiteSpace(package.Path) || !Directory.Exists(package.Path))
                     {
-                        var message = $"Could not package redistributable {redistributable.Name}, the path {package.Path} could not be found";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger?.LogError("Could not package redistributable '{RedistributableName}', the path {Path} could not be found", redistributable.Name, package.Path);
+                        return;
                     }
 
                     var archive = new Archive
@@ -176,9 +174,8 @@ namespace LANCommander.Server.Services
             }
             else
             {
-                var message = $"Could not package redistributable {redistributable.Name}, no packaging scripts are defined";
-                logger?.LogWarning(message);
-                throw new Exception(message);
+                logger?.LogWarning("Could not package redistributable '{RedistributableName}', no packaging scripts are defined", redistributable.Name);
+                return;
             }
         }
     }

--- a/LANCommander.Server.Services/ToolService.cs
+++ b/LANCommander.Server.Services/ToolService.cs
@@ -97,16 +97,14 @@ namespace LANCommander.Server.Services
 
                     if (package == null)
                     {
-                        var message = $"Could not package tool {tool.Name}, the package script did not return a result";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger?.LogError("Could not package tool '{ToolName}', the package script did not return a result", tool.Name);
+                        return;
                     }
 
                     if (String.IsNullOrWhiteSpace(package.Path) || !Directory.Exists(package.Path))
                     {
-                        var message = $"Could not package tool {tool.Name}, the path {package.Path} could not be found";
-                        logger?.LogError(message);
-                        throw new Exception(message);
+                        logger?.LogError("Could not package tool '{ToolName}', the path {Path} could not be found", tool.Name, package.Path);
+                        return;
                     }
 
                     var archive = new Archive
@@ -131,9 +129,8 @@ namespace LANCommander.Server.Services
             }
             else
             {
-                var message = $"Could not package tool {tool.Name}, no packaging scripts are defined";
-                logger?.LogWarning(message);
-                throw new Exception(message);
+                logger?.LogWarning("Could not package tool '{ToolName}', no packaging scripts are defined", tool.Name);
+                return;
             }
         }
     }

--- a/LANCommander.Server/Jobs/Recurring/AutomaticRepackage.cs
+++ b/LANCommander.Server/Jobs/Recurring/AutomaticRepackage.cs
@@ -1,5 +1,5 @@
-using Hangfire;
 using LANCommander.SDK.Enums;
+using LANCommander.Server.Data.Models;
 using LANCommander.Server.Services;
 
 namespace LANCommander.Server.Jobs.Recurring;
@@ -25,29 +25,72 @@ public sealed class AutomaticRepackage(
 
     public override async Task ExecuteAsync()
     {
-        if (!settingsProvider.CurrentValue.Server.Scripts.EnableAutomaticRepackaging)
+        // This job is not allowed to throw: an unhandled exception here is picked up by Hangfire's
+        // AutomaticRetryAttribute, which retries the *entire* job up to 10 times with an exponentially
+        // growing delay (over an hour by the later attempts). A single bad game/script should never be
+        // able to take down the whole recurring job, so every failure path below is caught and logged
+        // instead of being allowed to bubble out.
+        try
         {
-            logger.LogDebug("The automatic repackaging job attempted to execute, but automatic repackaging is disabled");
-            return;
-        }
-        
-        logger.LogInformation("Starting automatic repackaging job");
-        
-        var repackageScripts = await scriptService.GetAsync(s => s.Type == ScriptType.Package);
-        
-        logger.LogInformation("Found {ScriptCount} packaging scripts}", repackageScripts.Count);
+            if (!settingsProvider.CurrentValue.Server.Scripts.EnableAutomaticRepackaging)
+            {
+                logger.LogDebug("The automatic repackaging job attempted to execute, but automatic repackaging is disabled");
+                return;
+            }
 
-        foreach (var script in repackageScripts)
-        {
+            logger.LogInformation("Starting automatic repackaging job");
+
+            ICollection<Script>? repackageScripts;
+
             try
             {
-                if (script.GameId.HasValue)
-                    await gameService.PackageAsync(script.GameId.Value);
+                repackageScripts = await scriptService.GetAsync(s => s.Type == ScriptType.Package);
+
+                logger.LogInformation("Found {ScriptCount} packaging scripts", repackageScripts.Count);
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Could not automatically run packaging script with ID {ScriptId}", script.Id);
+                logger.LogError(ex, "Could not retrieve packaging scripts for automatic repackaging");
+                return;
             }
+
+            var succeeded = 0;
+            var failed = 0;
+
+            foreach (var script in repackageScripts)
+            {
+                try
+                {
+                    if (script.GameId.HasValue)
+                    {
+                        await gameService.PackageAsync(script.GameId.Value);
+                        succeeded++;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    failed++;
+
+                    logger.LogError(
+                        ex,
+                        "Could not automatically run packaging script with ID {ScriptId} for game {GameId}: {ExceptionType} - {ExceptionMessage}",
+                        script.Id,
+                        script.GameId,
+                        ex.GetType().Name,
+                        ex.Message);
+                }
+            }
+
+            logger.LogInformation(
+                "Finished automatic repackaging job: {SucceededCount} succeeded, {FailedCount} failed",
+                succeeded,
+                failed);
+        }
+        catch (Exception ex)
+        {
+            // Catch-all so an unexpected failure (e.g. a settings/service issue outside the per-script
+            // loop) is logged clearly instead of triggering Hangfire's long automatic-retry backoff.
+            logger.LogError(ex, "Automatic repackaging job failed unexpectedly: {ExceptionType} - {ExceptionMessage}", ex.GetType().Name, ex.Message);
         }
     }
 }

--- a/LANCommander.Server/Startup/Razor.cs
+++ b/LANCommander.Server/Startup/Razor.cs
@@ -1,9 +1,20 @@
+using Microsoft.AspNetCore.Components.Server;
+
 namespace LANCommander.Server.Startup;
 
 public static class Razor
 {
     public static WebApplicationBuilder AddRazor(this WebApplicationBuilder builder)
     {
+        // Long-running scripts (e.g. game/tool/redistributable packaging) drive JS interop calls
+        // through the PowerShell debug console (Terminal.ReadLineAsync/WriteLine) that can take far
+        // longer than Blazor Server's 1 minute default JSInteropDefaultCallTimeout. Raise it so those
+        // calls aren't cancelled mid-script.
+        builder.Services.Configure<CircuitOptions>(options =>
+        {
+            options.JSInteropDefaultCallTimeout = TimeSpan.FromMinutes(10);
+        });
+
         builder.Services
             .AddMvc(static options => options.EnableEndpointRouting = false)
             .AddRazorOptions(static options =>


### PR DESCRIPTION
•	Fix FormatException crashes in Hangfire package jobs caused by interpolated strings being passed as log format templates in ToolService/RedistributableService
•	Align ToolService/RedistributableService package failure handling with GameService — log and return instead of throwing generic Exception for expected script-return failures
•	Harden AutomaticRepackage recurring job with per-script try/catch and outer catch-all so a single failure doesn't trigger Hangfire's long automatic-retry backoff
•	Extend Blazor Server CircuitOptions.JSInteropDefaultCallTimeout to 10 minutes so long-running interactive package script debugging isn't cancelled by the 1-minute default