### PR TITLE
Ensuring redist scripts included in manifest

### DIFF
--- a/LANCommander.Server.Data/Models/Game.cs
+++ b/LANCommander.Server.Data/Models/Game.cs
@@ -7,7 +7,7 @@ namespace LANCommander.Server.Data.Models
     [Table("Games")]
     public class Game : BaseModel
     {
-        public ICollection<GameExternalId>? ExternalIds { get; set; }
+        public ICollection<GameExternalId> ExternalIds { get; set; } = [];
         public string Title { get; set; }
         [Display(Name = "Sort Title")]
         public string? SortTitle { get; set; }
@@ -34,32 +34,32 @@ namespace LANCommander.Server.Data.Models
         [ForeignKey(nameof(EngineId))]
         public virtual Engine Engine { get; set; }
 
-        public ICollection<MultiplayerMode>? MultiplayerModes { get; set; }
-        public ICollection<Genre>? Genres { get; set; } = new List<Genre>();
-        public ICollection<Tag>? Tags { get; set; } = new List<Tag>();
-        public ICollection<Platform>? Platforms { get; set; }
-        public ICollection<Category>? Categories { get; set; }
-        public ICollection<Company>? Publishers { get; set; }
-        public ICollection<Company>? Developers { get; set; }
-        public ICollection<Archive>? Archives { get; set; }
-        public ICollection<Script>? Scripts { get; set; }
-        public ICollection<GameSave>? GameSaves { get; set; }
-        public ICollection<PlaySession>? PlaySessions { get; set; }
-        public ICollection<SavePath>? SavePaths { get; set; }
-        public ICollection<Server>? Servers { get; set; }
-        public ICollection<Redistributable>? Redistributables { get; set; }
-        public ICollection<Tool>? Tools { get; set; }
-        public ICollection<Media>? Media { get; set; }
+        public ICollection<MultiplayerMode> MultiplayerModes { get; set; } = [];
+        public ICollection<Genre> Genres { get; set; } = [];
+        public ICollection<Tag> Tags { get; set; } = [];
+        public ICollection<Platform> Platforms { get; set; } = [];
+        public ICollection<Category> Categories { get; set; } = [];
+        public ICollection<Company> Publishers { get; set; } = [];
+        public ICollection<Company> Developers { get; set; } = [];
+        public ICollection<Archive> Archives { get; set; } = [];
+        public ICollection<Script> Scripts { get; set; } = [];
+        public ICollection<GameSave> GameSaves { get; set; } = [];
+        public ICollection<PlaySession> PlaySessions { get; set; } = [];
+        public ICollection<SavePath> SavePaths { get; set; } = [];
+        public ICollection<Server> Servers { get; set; } = [];
+        public ICollection<Redistributable> Redistributables { get; set; } = [];
+        public ICollection<Tool> Tools { get; set; } = [];
+        public ICollection<Media> Media { get; set; } = [];
 
         public string? ValidKeyRegex { get; set; }
-        public ICollection<Key>? Keys { get; set; }
-        public ICollection<Collection> Collections { get; set; }
-        public ICollection<Game> DependentGames { get; set; }
-        public ICollection<Issue> Issues { get; set; }
-        public ICollection<Page>? Pages { get; set; }
-        public ICollection<Library> Libraries { get; set; }
-        public ICollection<Rating>? Ratings { get; set; }
-        public ICollection<GameCustomField>? CustomFields { get; set; }
+        public ICollection<Key> Keys { get; set; } = [];
+        public ICollection<Collection> Collections { get; set; } = [];
+        public ICollection<Game> DependentGames { get; set; } = [];
+        public ICollection<Issue> Issues { get; set; } = [];
+        public ICollection<Page> Pages { get; set; } = [];
+        public ICollection<Library> Libraries { get; set; } = [];
+        public ICollection<Rating> Ratings { get; set; } = [];
+        public ICollection<GameCustomField> CustomFields { get; set; } = [];
         
         [NotMapped]
         public bool IsAddon => AddonTypes.Contains(Type);

--- a/LANCommander.Server.Data/Models/Redistributable.cs
+++ b/LANCommander.Server.Data/Models/Redistributable.cs
@@ -10,9 +10,9 @@ namespace LANCommander.Server.Data.Models
         public string? Notes { get; set; }
         public string? OptionSchema { get; set; }
 
-        public ICollection<Archive>? Archives { get; set; }
-        public ICollection<Script>? Scripts { get; set; }
-        public ICollection<Game>? Games { get; set; }
-        public ICollection<Page>? Pages { get; set; }
+        public ICollection<Archive> Archives { get; set; } = [];
+        public ICollection<Script> Scripts { get; set; } = [];
+        public ICollection<Game> Games { get; set; } = [];
+        public ICollection<Page> Pages { get; set; } = [];
     }
 }

--- a/LANCommander.Server.Services/GameService.cs
+++ b/LANCommander.Server.Services/GameService.cs
@@ -70,7 +70,7 @@ namespace LANCommander.Server.Services
             if (entity.Media != null)
                 foreach (var media in entity.Media.Where(m => m.Id == Guid.Empty && String.IsNullOrWhiteSpace(m.Crc32)).ToList())
                     entity.Media.Remove(media);
-            
+
             var update = await base.UpdateAsync(entity, async context =>
             {
                 await context.UpdateRelationshipAsync(g => g.Actions);
@@ -123,60 +123,63 @@ namespace LANCommander.Server.Services
             return await GetAsync(g => g.AddonTypes.Contains(g.Type));
         }
 
-        public async Task<SDK.Models.Manifest.Game> GetManifestAsync(Guid id)
+        public async Task<SDK.Models.Manifest.Game?> GetManifestAsync(Guid id)
         {
-            var game = await Query(q =>
+            var game = await Query(static q =>
             {
                 return q
                     .AsNoTracking()
                     .AsSplitQuery()
-                    .Include(g => g.Actions)
-                    .Include(g => g.Archives)
-                    .Include(g => g.BaseGame)
-                    .Include(g => g.Categories)
-                    .Include(g => g.Collections)
-                    .Include(g => g.CustomFields)
-                    .Include(g => g.DependentGames)
-                    .Include(g => g.Developers)
-                    .Include(g => g.Engine)
-                    .Include(g => g.Genres)
-                    .Include(g => g.Media)
-                    .Include(g => g.MultiplayerModes)
-                    .Include(g => g.Platforms)
-                    .Include(g => g.Publishers)
-                    .Include(g => g.Redistributables)
-                    .Include(g => g.Tools)
-                    .Include(g => g.SavePaths)
-                    .Include(g => g.Scripts)
-                    .Include(g => g.Tags)
-                    .Include(g => g.ExternalIds);
+                    .Include(static g => g.Actions)
+                    .Include(static g => g.Archives)
+                    .Include(static g => g.BaseGame)
+                    .Include(static g => g.Categories)
+                    .Include(static g => g.Collections)
+                    .Include(static g => g.CustomFields)
+                    .Include(static g => g.DependentGames)
+                    .Include(static g => g.Developers)
+                    .Include(static g => g.Engine)
+                    .Include(static g => g.Genres)
+                    .Include(static g => g.Media)
+                    .Include(static g => g.MultiplayerModes)
+                    .Include(static g => g.Platforms)
+                    .Include(static g => g.Publishers)
+                    .Include(static g => g.Redistributables)
+                        .ThenInclude(static r => r.Scripts)
+                    .Include(static g => g.Tools)
+                    .Include(static g => g.SavePaths)
+                    .Include(static g => g.Scripts)
+                    .Include(static g => g.Tags)
+                    .Include(static g => g.ExternalIds);
             }).GetAsync(id);
 
             return await GetManifestAsync(game);
         }
-        
-        public async Task<SDK.Models.Manifest.Game> GetManifestAsync(Game game)
+
+        public async Task<SDK.Models.Manifest.Game?> GetManifestAsync(Game game)
         {
             if (game == null)
                 return null;
 
             var manifest = mapper.Map<SDK.Models.Manifest.Game>(game);
 
-            if (game.Redistributables != null && game.Redistributables.Any())
+            if (game.Redistributables is not { Count: > 0 })
             {
-                using var context = await contextFactory.CreateDbContextAsync();
+                return manifest;
+            }
 
-                foreach (var redistributable in manifest.Redistributables)
+            using var context = await contextFactory.CreateDbContextAsync();
+
+            foreach (var redistributable in manifest.Redistributables)
+            {
+                var joinEntry = await context.Set<Dictionary<string, object>>("GameRedistributable")
+                    .FirstOrDefaultAsync(e =>
+                        EF.Property<Guid>(e, "GameId") == game.Id &&
+                        EF.Property<Guid>(e, "RedistributableId") == redistributable.Id);
+
+                if (joinEntry != null && joinEntry.TryGetValue("Options", out var options) && options is string optionsJson && !string.IsNullOrWhiteSpace(optionsJson))
                 {
-                    var joinEntry = await context.Set<Dictionary<string, object>>("GameRedistributable")
-                        .FirstOrDefaultAsync(e =>
-                            EF.Property<Guid>(e, "GameId") == game.Id &&
-                            EF.Property<Guid>(e, "RedistributableId") == redistributable.Id);
-
-                    if (joinEntry != null && joinEntry.TryGetValue("Options", out var options) && options is string optionsJson && !string.IsNullOrWhiteSpace(optionsJson))
-                    {
-                        redistributable.Options = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(optionsJson);
-                    }
+                    redistributable.Options = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, string>>(optionsJson) ?? [];
                 }
             }
 
@@ -220,7 +223,7 @@ namespace LANCommander.Server.Services
                 .AsSplitQuery()
                 .Include(g => g.CustomFields)
                 .GetAsync(id);
-            
+
             return game.CustomFields.FirstOrDefault(c => c.Name == name);
         }
 
@@ -230,7 +233,7 @@ namespace LANCommander.Server.Services
                 .AsSplitQuery()
                 .Include(g => g.CustomFields)
                 .GetAsync(id);
-            
+
             if (game.CustomFields.Any(c => c.Name == name))
                 foreach (var customField in game.CustomFields.Where(c => c.Name == name))
                     customField.Value = value;
@@ -248,9 +251,9 @@ namespace LANCommander.Server.Services
                 .AsSplitQuery()
                 .Include(g => g.Archives)
                 .GetAsync(id);
-            
+
             var latestArchive = game.Archives.OrderByDescending(a => a.CreatedOn).FirstOrDefault();
-            
+
             return latestArchive;
         }
 
@@ -296,7 +299,7 @@ namespace LANCommander.Server.Services
                 .Include(g => g.CustomFields)
                 .Include(g => g.Scripts)
                 .GetAsync(id);
-            
+
             logger.LogInformation("Packaging game {GameTitle}", game.Title);
 
             var latestArchive = game.Archives?.OrderByDescending(a => a.CreatedOn).FirstOrDefault();
@@ -337,9 +340,9 @@ namespace LANCommander.Server.Services
                     };
 
                     archive = await archiveService.AddAsync(archive);
-                    
+
                     var destination = await archiveService.GetArchiveFileLocationAsync(archive);
-                    
+
                     ZipFile.CreateFromDirectory(package.Path, destination);
 
                     await archiveService.RecalculateFileSizeArchiveAsync(archive);


### PR DESCRIPTION
The EF query wasn't loading the Redistributable.Scripts collection from the database when generating the manifest. Use this as a chance to remove a bunch of null warnings with the DTOs
