### PR TITLE
fix(ci): move launcher visual-diff PR comment to workflow_run trigger

### DIFF
--- a/.github/workflows/LANCommander.Launcher.Tests.PRComment.yml
+++ b/.github/workflows/LANCommander.Launcher.Tests.PRComment.yml
@@ -1,24 +1,24 @@
 name: LANCommander Launcher Tests — PR Visual Diff Comment
 
+# Triggered by workflow_run (not workflow_call/pull_request_target) so this
+# job gets a trusted, elevated GITHUB_TOKEN even when the underlying PR came
+# from a fork. A pull_request-triggered job's token is read-only for forks,
+# which caused the push to gh-visual-diffs and the PR comment to fail with a
+# 403 when the PR author isn't a member/contributor.
 on:
-    workflow_call:
-        inputs:
-            pr_number:
-                description: 'Pull request number to comment on'
-                required: true
-                type: string
-            artifact_run_id:
-                description: 'Workflow run ID that produced the launcher-visual-artifacts artifact'
-                required: true
-                type: string
+    workflow_run:
+        workflows: ["LANCommander Pull Request"]
+        types: [completed]
 
 permissions:
     contents: write       # push diff PNGs to the gh-visual-diffs branch
     pull-requests: write  # post / update the comment
+    actions: read         # download artifacts from the triggering run
 
 jobs:
     comment:
         runs-on: ubuntu-latest
+        if: github.event.workflow_run.event == 'pull_request'
         steps:
             - name: Checkout for branch push
               uses: actions/checkout@v4
@@ -26,23 +26,34 @@ jobs:
                   fetch-depth: 0
 
             - name: Download visual artifacts
+              id: download
+              continue-on-error: true
               uses: actions/download-artifact@v4
               with:
                   name: launcher-visual-artifacts
                   path: visual
-                  run-id: ${{ inputs.artifact_run_id }}
+                  run-id: ${{ github.event.workflow_run.id }}
                   github-token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Read regression manifest
               id: manifest
               run: |
-                  if [ ! -f visual/regressions.json ]; then
+                  if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -f visual/regressions.json ]; then
                       echo "no manifest — assuming no visual run"
                       echo "count=0" >> "$GITHUB_OUTPUT"
                       exit 0
                   fi
                   count=$(jq '.regressed_count' visual/regressions.json)
                   echo "count=$count" >> "$GITHUB_OUTPUT"
+
+            - name: Determine PR number
+              id: pr
+              run: |
+                  if [ -f visual/pr-number.txt ]; then
+                      echo "number=$(cat visual/pr-number.txt)" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Skip when no regressions
               if: steps.manifest.outputs.count == '0'
@@ -53,8 +64,8 @@ jobs:
             - name: Push diffs to gh-visual-diffs branch
               if: steps.manifest.outputs.count != '0'
               env:
-                  PR: ${{ inputs.pr_number }}
-                  RUN: ${{ inputs.artifact_run_id }}
+                  PR: ${{ steps.pr.outputs.number }}
+                  RUN: ${{ github.event.workflow_run.id }}
               run: |
                   set -euo pipefail
                   git config user.name  "github-actions[bot]"
@@ -88,8 +99,8 @@ jobs:
               if: steps.manifest.outputs.count != '0'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  PR: ${{ inputs.pr_number }}
-                  RUN: ${{ inputs.artifact_run_id }}
+                  PR: ${{ steps.pr.outputs.number }}
+                  RUN: ${{ github.event.workflow_run.id }}
                   REPO: ${{ github.repository }}
                   MARKER: '<!-- launcher-visual-diff-comment -->'
               run: |

--- a/.github/workflows/LANCommander.Launcher.Tests.yml
+++ b/.github/workflows/LANCommander.Launcher.Tests.yml
@@ -7,6 +7,10 @@ on:
                 description: 'Build .NET Version'
                 required: true
                 type: string
+            pr_number:
+                description: 'Pull request number, if this run is associated with one'
+                required: false
+                type: string
         outputs:
             visual_diff_count:
                 description: 'Number of visual baselines that regressed in this run'
@@ -139,6 +143,10 @@ jobs:
 
                   cat visual/regressions.json
 
+            - name: Save PR number
+              if: always() && inputs.pr_number != ''
+              run: echo "${{ inputs.pr_number }}" > visual/pr-number.txt
+
             - name: Upload visual artifacts
               if: always()
               uses: actions/upload-artifact@v4
@@ -149,6 +157,7 @@ jobs:
                       visual/diffs/**
                       visual/baselines/**
                       visual/regressions.json
+                      visual/pr-number.txt
                   if-no-files-found: warn
                   retention-days: 14
 

--- a/.github/workflows/LANCommander.PR.yml
+++ b/.github/workflows/LANCommander.PR.yml
@@ -233,13 +233,9 @@ jobs:
         uses: ./.github/workflows/LANCommander.Launcher.Tests.yml
         with:
             build_dotnet_version: ${{ needs.prep.outputs.build_dotnet_version }}
-
-    launcher_tests_pr_comment:
-        # Always run after the test job — even on failure — so visual regressions
-        # show up as a PR comment instead of being buried in the artifact.
-        needs: [launcher_tests]
-        if: always() && needs.launcher_tests.result != 'cancelled' && github.event.pull_request.number != null
-        uses: ./.github/workflows/LANCommander.Launcher.Tests.PRComment.yml
-        with:
-            pr_number:       ${{ github.event.pull_request.number }}
-            artifact_run_id: ${{ github.run_id }}
+            pr_number: ${{ github.event.pull_request.number }}
+        # The PR comment is posted by a separate workflow_run-triggered workflow
+        # (LANCommander.Launcher.Tests.PRComment.yml) so it runs with elevated,
+        # trusted permissions even for PRs from forks — a pull_request-triggered
+        # job's GITHUB_TOKEN is read-only for fork PRs and cannot push branches
+        # or comment.


### PR DESCRIPTION
## Problem

The `launcher_tests_pr_comment` job ran via `workflow_call` inside the `pull_request`-triggered `LANCommander Pull Request` workflow. GitHub forces the `GITHUB_TOKEN` to read-only for `pull_request` events when the PR author isn't a member/contributor, so:
- `git push origin gh-visual-diffs` failed with `403`
- posting/updating the PR comment would also fail

See failing run: https://github.com/LANCommander/LANCommander/actions/runs/33572786585/job/100070668526

## Fix

Following the pattern from [github/awesome-copilot#2625](https://github.com/github/awesome-copilot/pull/2625):
- `LANCommander.Launcher.Tests.yml` now writes the PR number into the uploaded `launcher-visual-artifacts` artifact.
- `LANCommander.PR.yml` no longer calls the comment workflow directly; it just passes `pr_number` through to the test job.
- `LANCommander.Launcher.Tests.PRComment.yml` is now triggered by `workflow_run` (after `LANCommander Pull Request` completes) instead of `workflow_call`. `workflow_run` always uses the default, trusted `GITHUB_TOKEN` with the declared job permissions, regardless of whether the triggering PR came from a fork or non-contributor, since it never checks out untrusted PR code — it only downloads the artifact the (sandboxed) test job already produced.

This restores visual-regression PR comments for all contributors, including first-time/external ones.