### PR TITLE
CVE fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup Label="Aspire">
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="9.5.2" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.1.1" />
     <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
     <PackageVersion Include="EasyMDE.Blazor" Version="1.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,6 +42,7 @@
     <PackageVersion Include="Superpower" Version="3.1.0" />
     <PackageVersion Include="RegParserDotNet" Version="1.1.1" />
     <PackageVersion Include="nulastudio.NetBeauty" Version="2.1.4.6" />
+    <PackageVersion Include="NuGet.CommandLine" Version="6.12.5" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.5" />
     <PackageVersion Include="NuGet.Protocol" Version="6.12.5" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Superpower" Version="3.1.0" />
     <PackageVersion Include="RegParserDotNet" Version="1.1.1" />
     <PackageVersion Include="nulastudio.NetBeauty" Version="2.1.4.6" />
+    <PackageVersion Include="NuGet.Packaging" Version="6.12.5" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -69,7 +69,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
   </ItemGroup>
   <ItemGroup Label="Testing">
-    <PackageVersion Include="bunit" Version="1.40.0" />
+    <PackageVersion Include="bunit" Version="2.9.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -75,6 +75,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.7.1" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.12.50" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.12" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,11 +103,11 @@
     <PackageVersion Include="SteamWebAPI2" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Label="Entity Framework Core">
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.19" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.19" />
     <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -89,7 +89,7 @@
     <PackageVersion Include="CoreRCON" Version="5.0.5" />
     <PackageVersion Include="LANCommander.HQ.SDK" Version="1.1.2" />
     <PackageVersion Include="craftersmine.SteamGridDB.Net" Version="1.1.7" />
-    <PackageVersion Include="YoutubeExplode" Version="6.4.3" />
+    <PackageVersion Include="YoutubeExplode" Version="6.6.2" />
     <PackageVersion Include="Docker.DotNet.Enhanced" Version="3.129.0" />
     <PackageVersion Include="Facepunch.Steamworks" Version="2.3.3" />
     <PackageVersion Include="IGDB" Version="6.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -100,7 +100,7 @@
     <PackageVersion Include="rix0rrr.BeaconLib" Version="1.0.2" />
     <PackageVersion Include="Semver" Version="3.0.0" />
     <PackageVersion Include="SharpCompress" Version="0.50.0" />
-    <PackageVersion Include="SteamWebAPI2" Version="4.4.1" />
+    <PackageVersion Include="SteamWebAPI2" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup Label="Entity Framework Core">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -178,6 +178,7 @@
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.1" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
     <PackageVersion Include="System.Text.Json" Version="9.0.1" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.95.0" />
   </ItemGroup>
   <ItemGroup Label="Caching">
     <PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.1.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Svrooij.PowerShell.DI" Version="1.3.4" />
   </ItemGroup>
   <ItemGroup Label="AutoMapper">
-    <PackageVersion Include="AutoMapper" Version="14.0.0" />
+    <PackageVersion Include="AutoMapper" Version="15.1.3" />
   </ItemGroup>
   <ItemGroup Label="AntDesign">
     <PackageVersion Include="AntDesign" Version="1.6.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.8" />
     <PackageVersion Include="Notify.NET" Version="1.1.0" />
     <PackageVersion Include="Svrooij.PowerShell.DI" Version="1.3.4" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.29" />
   </ItemGroup>
   <ItemGroup Label="AutoMapper">
     <PackageVersion Include="AutoMapper" Version="15.1.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -117,9 +117,9 @@
     <PackageVersion Include="Hangfire.InMemory" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup Label="PowerShell">
-    <PackageVersion Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.4.7" />
-    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.7" />
-    <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
+    <PackageVersion Include="Microsoft.PowerShell.Commands.Diagnostics" Version="7.4.19" />
+    <PackageVersion Include="Microsoft.PowerShell.SDK" Version="7.4.19" />
+    <PackageVersion Include="System.Management.Automation" Version="7.4.19" />
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -125,7 +125,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.19" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.1" />
@@ -134,7 +134,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="9.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.19" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.9" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,6 +42,7 @@
     <PackageVersion Include="RegParserDotNet" Version="1.1.1" />
     <PackageVersion Include="nulastudio.NetBeauty" Version="2.1.4.6" />
     <PackageVersion Include="NuGet.Packaging" Version="6.12.5" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.5" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />
     <PackageVersion Include="NetEscapades.Configuration.Yaml" Version="3.1.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -76,7 +76,7 @@
     <PackageVersion Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.7.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.12" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.11" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -141,11 +141,11 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="9.4.0" />
   </ItemGroup>
   <ItemGroup Label="OpenTelemetry">
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
   </ItemGroup>
   <ItemGroup Label="LibVLC">
     <PackageVersion Include="LibVLCSharp" Version="3.8.5" />

--- a/LANCommander.AppHost/LANCommander.AppHost.csproj
+++ b/LANCommander.AppHost/LANCommander.AppHost.csproj
@@ -12,6 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" />
+        <PackageReference Include="StreamJsonRpc" />
     </ItemGroup>
 
     <ItemGroup>

--- a/LANCommander.Launcher/LANCommander.Launcher.csproj
+++ b/LANCommander.Launcher/LANCommander.Launcher.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="VideoLAN.LibVLC.Windows" Condition="$(RuntimeIdentifier.StartsWith('win')) OR ($([MSBuild]::IsOSPlatform('Windows')) AND '$(RuntimeIdentifier)' == '')" />
     <PackageReference Include="VideoLAN.LibVLC.Mac" Condition="$(RuntimeIdentifier.StartsWith('osx')) OR ($([MSBuild]::IsOSPlatform('OSX')) AND '$(RuntimeIdentifier)' == '')" />
     <PackageReference Include="ppy.SDL3-CS" />
+    <PackageReference Include="Tmds.DBus.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LANCommander.Packager/LANCommander.Packager.csproj
+++ b/LANCommander.Packager/LANCommander.Packager.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" />
     <PackageReference Include="YamlDotNet" />
+    <PackageReference Include="Tmds.DBus.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LANCommander.SDK/Helpers/TextFileHelper.cs
+++ b/LANCommander.SDK/Helpers/TextFileHelper.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Text.RegularExpressions;
-using AutoMapper;
 
 namespace LANCommander.SDK.Helpers;
 

--- a/LANCommander.Server.Services/LANCommander.Server.Services.csproj
+++ b/LANCommander.Server.Services/LANCommander.Server.Services.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Octokit" />
+    <PackageReference Include="NuGet.CommandLine" />
     <PackageReference Include="rix0rrr.BeaconLib" />
     <PackageReference Include="Semver" />
     <PackageReference Include="SixLabors.ImageSharp" />

--- a/LANCommander.Server.UI.Tests/Components/BUnitTestContext.cs
+++ b/LANCommander.Server.UI.Tests/Components/BUnitTestContext.cs
@@ -13,7 +13,7 @@ namespace LANCommander.Server.UI.Tests.Components;
 /// created by <see cref="BUnitServerFixture"/> via a fallback service provider. A fresh scope is
 /// created per test so scoped services (and their DbContexts) behave like a single request.
 /// </summary>
-public abstract class BUnitTestContext : Bunit.TestContext
+public abstract class BUnitTestContext : BunitContext
 {
     private readonly IServiceScope _scope;
 
@@ -56,7 +56,7 @@ public abstract class BUnitTestContext : Bunit.TestContext
 
         // Admin pages are gated with [Authorize(Roles = Administrator)]. Provide an authenticated
         // admin so AuthorizeView/cascading auth state behave as in a logged-in session.
-        var authContext = this.AddTestAuthorization();
+        var authContext = this.AddAuthorization();
         authContext.SetAuthorized(TestConstants.AdminUserName);
         authContext.SetRoles(RoleService.AdministratorRoleName);
 

--- a/LANCommander.Server.UI.Tests/Components/GameEditComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/GameEditComponentTests.cs
@@ -20,7 +20,7 @@ public class GameEditComponentTests : BUnitTestContext
     }
 
     private IRenderedComponent<General> RenderGeneral()
-        => RenderComponent<General>(parameters => parameters
+        => Render<General>(parameters => parameters
             .Add(p => p.Id, Fixture.TestGameId));
 
     [Fact]

--- a/LANCommander.Server.UI.Tests/Components/MetadataComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/MetadataComponentTests.cs
@@ -31,7 +31,7 @@ public class MetadataComponentTests : BUnitTestContext
     {
         await ClearTagsAsync();
 
-        var cut = RenderComponent<TagsIndex>();
+        var cut = Render<TagsIndex>();
 
         Assert.Contains(
             cut.FindAll("button"),
@@ -49,7 +49,7 @@ public class MetadataComponentTests : BUnitTestContext
     {
         await ClearTagsAsync();
 
-        var cut = RenderComponent<TagsIndex>();
+        var cut = Render<TagsIndex>();
 
         // Open the "New Tag" modal.
         var addButton = cut.FindAll("button")

--- a/LANCommander.Server.UI.Tests/Components/ProfileComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/ProfileComponentTests.cs
@@ -19,7 +19,7 @@ public class ProfileComponentTests : BUnitTestContext
     [Fact]
     public void Profile_ShowsCurrentUsername()
     {
-        var cut = RenderComponent<ProfileIndex>();
+        var cut = Render<ProfileIndex>();
 
         // The authenticated admin's username is bound into the username input.
         Assert.Contains(TestConstants.AdminUserName, cut.Markup);
@@ -28,7 +28,7 @@ public class ProfileComponentTests : BUnitTestContext
     [Fact]
     public void Profile_ShowsFormElements()
     {
-        var cut = RenderComponent<ProfileIndex>();
+        var cut = Render<ProfileIndex>();
 
         foreach (var label in new[] { "Username", "Alias", "Email Address" })
         {

--- a/LANCommander.Server.UI.Tests/Components/RoleManagementComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/RoleManagementComponentTests.cs
@@ -21,7 +21,7 @@ public class RoleManagementComponentTests : BUnitTestContext
     [Fact]
     public void Roles_ShowsAddRoleButtonAndAdministratorRole()
     {
-        var cut = RenderComponent<RolesIndex>();
+        var cut = Render<RolesIndex>();
 
         Assert.Contains(
             cut.FindAll("button"),

--- a/LANCommander.Server.UI.Tests/Components/SettingsComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/SettingsComponentTests.cs
@@ -18,7 +18,7 @@ public class SettingsComponentTests : BUnitTestContext
     [Fact]
     public void SettingsGeneral_ShowsFormElements()
     {
-        var cut = RenderComponent<SettingsGeneral>();
+        var cut = Render<SettingsGeneral>();
 
         Assert.Contains("Port", cut.Markup);
         Assert.Contains("Use SSL", cut.Markup);

--- a/LANCommander.Server.UI.Tests/Components/UserManagementComponentTests.cs
+++ b/LANCommander.Server.UI.Tests/Components/UserManagementComponentTests.cs
@@ -18,7 +18,7 @@ public class UserManagementComponentTests : BUnitTestContext
     [Fact]
     public void Users_ShowsSeededAdminUser()
     {
-        var cut = RenderComponent<UsersIndex>();
+        var cut = Render<UsersIndex>();
 
         // The DataTable loads rows asynchronously after first render; poll until the seeded
         // admin user appears.

--- a/LANCommander.Server/LANCommander.Server.csproj
+++ b/LANCommander.Server/LANCommander.Server.csproj
@@ -100,6 +100,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" />

--- a/LANCommander.Server/LANCommander.Server.csproj
+++ b/LANCommander.Server/LANCommander.Server.csproj
@@ -103,6 +103,7 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
+    <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" />
     <PackageReference Include="nulastudio.NetBeauty" />
     <PackageReference Include="Razor.Templating.Core" />

--- a/LANCommander.Server/LANCommander.Server.csproj
+++ b/LANCommander.Server/LANCommander.Server.csproj
@@ -104,6 +104,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NetEscapades.Configuration.Yaml" />
     <PackageReference Include="nulastudio.NetBeauty" />
     <PackageReference Include="Razor.Templating.Core" />

--- a/LANCommander.slnx
+++ b/LANCommander.slnx
@@ -1,18 +1,18 @@
-﻿<Solution>
+<Solution>
   <Folder Name="/Configuration/">
     <File Path="Directory.Packages.props" />
   </Folder>
   <Folder Name="/LANCommander.Launcher/">
-    <Project Path="LANCommander.Launcher/LANCommander.Launcher.csproj" />
     <Project Path="LANCommander.Launcher.Data\LANCommander.Launcher.Data.csproj" />
     <Project Path="LANCommander.Launcher.Models\LANCommander.Launcher.Models.csproj" />
     <Project Path="LANCommander.Launcher.Services\LANCommander.Launcher.Services.csproj" />
-    <Project Path="LANCommander.Launcher.Settings\LANCommander.Launcher.Settings.csproj" Type="C#" />
+    <Project Path="LANCommander.Launcher.Settings\LANCommander.Launcher.Settings.csproj" />
+    <Project Path="LANCommander.Launcher/LANCommander.Launcher.csproj" />
   </Folder>
   <Folder Name="/LANCommander.Server/">
-    <Project Path="LANCommander.Server.ImportExport\LANCommander.Server.ImportExport.csproj" Type="C#" />
+    <Project Path="LANCommander.Server.ImportExport\LANCommander.Server.ImportExport.csproj" />
     <Project Path="LANCommander.Server.Services\LANCommander.Server.Services.csproj" />
-    <Project Path="LANCommander.Server.Settings\LANCommander.Server.Settings.csproj" Type="C#" />
+    <Project Path="LANCommander.Server.Settings\LANCommander.Server.Settings.csproj" />
     <Project Path="LANCommander.Server\LANCommander.Server.csproj" />
   </Folder>
   <Folder Name="/LANCommander.Server/LANCommander.Server.Data/">
@@ -23,10 +23,10 @@
   </Folder>
   <Folder Name="/LANCommander.Tests/">
     <Project Path="LANCommander.Launcher.IntegrationTests\LANCommander.Launcher.IntegrationTests.csproj" />
-    <Project Path="LANCommander.Launcher.Tests\LANCommander.Launcher.Tests.csproj" />
     <Project Path="LANCommander.Launcher.Services.Tests\LANCommander.Launcher.Services.Tests.csproj" />
+    <Project Path="LANCommander.Launcher.Tests\LANCommander.Launcher.Tests.csproj" />
     <Project Path="LANCommander.SDK.Tests\LANCommander.SDK.Tests.csproj" />
-    <Project Path="LANCommander.Server.Tests\LANCommander.Server.Tests.csproj" Type="C#" />
+    <Project Path="LANCommander.Server.Tests\LANCommander.Server.Tests.csproj" />
     <Project Path="LANCommander.Server.UI.Tests\LANCommander.Server.UI.Tests.csproj" />
   </Folder>
   <Folder Name="/Scripts/">
@@ -34,15 +34,16 @@
     <File Path="Scripts\Send-UdpBroadcast.ps1" />
   </Folder>
   <Folder Name="/Solution Items/">
+    <File Path="Directory.Packages.props" />
     <File Path="Microsoft.Common.props" />
   </Folder>
-  <Project Path="LANCommander.AppHost\LANCommander.AppHost.csproj" Type="C#" />
+  <Project Path="LANCommander.AppHost\LANCommander.AppHost.csproj" />
   <Project Path="LANCommander.AutoUpdater\LANCommander.AutoUpdater.csproj" />
-  <Project Path="LANCommander.SDK\LANCommander.SDK.csproj" />
-  <Project Path="LANCommander.ServiceDefaults\LANCommander.ServiceDefaults.csproj" Type="C#" />
-  <Project Path="LANCommander.Steam\LANCommander.Steam.csproj" />
-  <Project Path="LANCommander.UI\LANCommander.UI.csproj" />
   <Project Path="LANCommander.CompletionGenerator\LANCommander.CompletionGenerator.csproj" />
   <Project Path="LANCommander.Packager\LANCommander.Packager.csproj" />
   <Project Path="LANCommander.SDK.SourceGenerators\LANCommander.SDK.SourceGenerators.csproj" />
+  <Project Path="LANCommander.SDK\LANCommander.SDK.csproj" />
+  <Project Path="LANCommander.ServiceDefaults\LANCommander.ServiceDefaults.csproj" />
+  <Project Path="LANCommander.Steam\LANCommander.Steam.csproj" />
+  <Project Path="LANCommander.UI\LANCommander.UI.csproj" />
 </Solution>


### PR DESCRIPTION
Going through the outstanding CVEs on the NuGet packages and updating the packages to resolve them. These are mostly minor or patch updates on packages that resulted in little to no actual code changes.



Some small changes needed with the StreamWebAPI2 and bunit bumps as they went across versions



* **Adding Directory.Packages.props to the slnx so it's easier to work with in VS**
* **Bumping automapper version**
* **Updating SteamWebAPI2 to 5.0.0**
* **Updating the PowerShell SDK libraries to resolve a CVE in System.Security.Cryptography.Xml**
* **Bumping OTEL to 1.18.0 and resolving the outstanding CVE**
* **Updating EF and SQLite deps to resolve a CVE**
* **Updating some base deps that EF also required updating**
* **Tackling most of the AngleSharp CVE paths by updating YoutubeExplode**
* **Updating bunit to resolve the last AngleSharp dangling CVE**
* **Updating Microsoft.VisualStudio.Web.CodeGeneration.Design to 9.0.12**
* **Updating Aspire.Hosting.AppHost to 9.5.2**
* **Updating Tmds.DBus.Protocol to 0.95.0**
* **Updating Microsoft.Build.Tasks.Core to 17.12.50**
* **Updating NuGet.Packaging to 6.12.5**
* **Updating NuGet.Protocol to 6.12.5**
* **Adding Tmds.DBus.Protocol pin to LANCommander.Packager**
* **Updating StreamJsonRpc to 2.25.29**
* **Updating NuGet.CommandLine to 6.12.5**

