### PR TITLE
Split server Docker images by optional dependencies

### DIFF
--- a/.github/workflows/LANCommander.Development.yml
+++ b/.github/workflows/LANCommander.Development.yml
@@ -138,8 +138,11 @@ jobs:
       - build_server_win_x64
     if: needs.prep.outputs.changed == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [base, full]
     steps:
-      # 3c) Build and push Docker image with tag "development"
+      # 3c) Build and push the base and full Docker images.
       - name: Checkout Repo for Docker build
         uses: actions/checkout@v4
 
@@ -183,16 +186,16 @@ jobs:
         with:
           platforms: linux/amd64
 
-      - name: Build and push Docker image
+      - name: Publish ${{ matrix.variant }} Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           context: ./LANCommander.Server
-          file: ./LANCommander.Server/Dockerfile
+          file: ./LANCommander.Server/${{ matrix.variant == 'full' && 'Dockerfile.full' || 'Dockerfile' }}
           push: true
           platforms: linux/amd64
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:development
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:${{ matrix.variant == 'full' && 'development-full' || 'development' }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -201,7 +204,7 @@ jobs:
             BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           provenance: true
 
-      - name: Generate artifact attestation
+      - name: Generate image attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
@@ -209,9 +212,11 @@ jobs:
           push-to-registry: true
 
       - name: Save version to artifact
+        if: matrix.variant == 'base'
         run: echo "${{ needs.prep.outputs.version_tag }}" > version.txt
 
       - name: Upload version artifact
+        if: matrix.variant == 'base'
         uses: actions/upload-artifact@v4
         with:
           name: version.${{ needs.prep.outputs.version_tag }}

--- a/.github/workflows/LANCommander.Nightly.Server.yml
+++ b/.github/workflows/LANCommander.Nightly.Server.yml
@@ -161,6 +161,9 @@ jobs:
       - build_server_win_x64
     if: needs.prep.outputs.should_build == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [base, full]
     steps:
       - name: Checkout Repo for Docker build
         uses: actions/checkout@v4
@@ -211,17 +214,17 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Build and push Docker image
+      - name: Publish ${{ matrix.variant }} Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           context: ./LANCommander.Server
-          file: ./LANCommander.Server/Dockerfile
+          file: ./LANCommander.Server/${{ matrix.variant == 'full' && 'Dockerfile.full' || 'Dockerfile' }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.variant == 'full' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:nightly
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:v${{ needs.prep.outputs.version_tag }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:${{ matrix.variant == 'full' && 'nightly-full' || 'nightly' }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:v${{ needs.prep.outputs.version_tag }}${{ matrix.variant == 'full' && '-full' || '' }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -230,7 +233,7 @@ jobs:
             BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           provenance: true
 
-      - name: Generate artifact attestation
+      - name: Generate image attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
@@ -238,9 +241,11 @@ jobs:
           push-to-registry: true
 
       - name: Save version to artifact
+        if: matrix.variant == 'base'
         run: echo "${{ needs.prep.outputs.version_tag }}" > version.txt
 
       - name: Upload version artifact
+        if: matrix.variant == 'base'
         uses: actions/upload-artifact@v4
         with:
           name: version.${{ needs.prep.outputs.version_tag }}

--- a/.github/workflows/LANCommander.Release.yml
+++ b/.github/workflows/LANCommander.Release.yml
@@ -390,35 +390,31 @@ jobs:
             artifacts/LANCommander.Launcher-Linux-x64-v${{ needs.prep.outputs.version_tag }}.AppImage
             artifacts/LANCommander.Packager-Windows-x86-v${{ needs.prep.outputs.version_tag }}.zip
 
+  publish_docker_image:
+    needs:
+      - prep
+      - build_server_linux_arm64
+      - build_server_linux_x64
+    if: needs.prep.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        variant: [base, full]
+    steps:
       - name: Checkout Repo for Docker build
         uses: actions/checkout@v4
-
-      - name: Download Server x64 Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: LANCommander.Server-Linux-x64-v${{ needs.prep.outputs.version_tag }}.zip
-          path: ./
-    
-      - name: Extract Server Artifacts
-        run: |
-          mkdir -p ./LANCommander.Server/published
-          unzip ./LANCommander.Server-Linux-x64-v${{ needs.prep.outputs.version_tag }}.zip -d ./LANCommander.Server/published
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-  
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Download Server x64 Artifacts
         uses: actions/download-artifact@v4
@@ -427,6 +423,7 @@ jobs:
           path: ./
 
       - name: Download Server arm64 Artifacts
+        if: matrix.variant == 'base'
         uses: actions/download-artifact@v4
         with:
           name: LANCommander.Server-Linux-arm64-v${{ needs.prep.outputs.version_tag }}.zip
@@ -438,11 +435,13 @@ jobs:
           unzip ./LANCommander.Server-Linux-x64-v${{ needs.prep.outputs.version_tag }}.zip -d ./LANCommander.Server/published-amd64
 
       - name: Extract Server Artifacts arm64
+        if: matrix.variant == 'base'
         run: |
           mkdir -p ./LANCommander.Server/published-arm64
           unzip ./LANCommander.Server-Linux-arm64-v${{ needs.prep.outputs.version_tag }}.zip -d ./LANCommander.Server/published-arm64
 
       - name: Set up QEMU
+        if: matrix.variant == 'base'
         uses: docker/setup-qemu-action@v2
 
       - name: Setup buildx
@@ -450,17 +449,17 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Build and push Docker image
+      - name: Publish ${{ matrix.variant }} Docker image
         id: push
         uses: docker/build-push-action@v6
         with:
           context: ./LANCommander.Server
-          file: ./LANCommander.Server/Dockerfile
+          file: ./LANCommander.Server/${{ matrix.variant == 'full' && 'Dockerfile.full' || 'Dockerfile' }}
           push: true
-          platforms: linux/amd64
+          platforms: ${{ matrix.variant == 'full' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:v${{ needs.prep.outputs.version_tag }}
-            ${{ needs.prep.outputs.is_prerelease == 'true' && format('{0}/{1}:prerelease', env.REGISTRY, env.IMAGE_NAME) || format('{0}/{1}:latest', env.REGISTRY, env.IMAGE_NAME) }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:v${{ needs.prep.outputs.version_tag }}${{ matrix.variant == 'full' && '-full' || '' }}
+            ${{ needs.prep.outputs.is_prerelease == 'true' && format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, matrix.variant == 'full' && 'prerelease-full' || 'prerelease') || format('{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, matrix.variant == 'full' && 'latest-full' || 'latest') }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -469,7 +468,7 @@ jobs:
             BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           provenance: true
 
-      - name: Generate artifact attestation
+      - name: Generate image attestation
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}

--- a/LANCommander.Server/Dockerfile
+++ b/LANCommander.Server/Dockerfile
@@ -10,8 +10,22 @@ COPY ./published-${TARGETARCH} /app
 COPY entrypoint.sh /app/entrypoint.sh
 COPY steamcmd.sh /usr/local/bin/steamcmd
 
-# Make entrypoint script executable
-RUN chmod +x /app/entrypoint.sh
-RUN chmod +x /usr/local/bin/steamcmd
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN case "$(dpkg --print-architecture)" in \
+    amd64) ytdlp_asset="yt-dlp_linux" ;; \
+    arm64) ytdlp_asset="yt-dlp_linux_aarch64" ;; \
+    armhf) ytdlp_asset="yt-dlp_linux_armv7l" ;; \
+    *) ytdlp_asset="yt-dlp_linux" ;; \
+  esac \
+  && curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ytdlp_asset}" -o /usr/local/bin/yt-dlp \
+  && chmod +x /usr/local/bin/yt-dlp
+
+RUN chmod +x /app/entrypoint.sh /usr/local/bin/steamcmd
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/LANCommander.Server/Dockerfile.full
+++ b/LANCommander.Server/Dockerfile.full
@@ -1,0 +1,59 @@
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS base
+WORKDIR /app
+ENV LANCOMMANDER_FULL_IMAGE=1
+
+EXPOSE 1337
+EXPOSE 213/udp
+EXPOSE 35891/udp
+
+ARG TARGETARCH
+COPY ./published-${TARGETARCH} /app
+COPY entrypoint.sh /app/entrypoint.sh
+COPY steamcmd.sh /usr/local/bin/steamcmd
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    ffmpeg \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN case "$(dpkg --print-architecture)" in \
+    amd64) ytdlp_asset="yt-dlp_linux" ;; \
+    arm64) ytdlp_asset="yt-dlp_linux_aarch64" ;; \
+    armhf) ytdlp_asset="yt-dlp_linux_armv7l" ;; \
+    *) ytdlp_asset="yt-dlp_linux" ;; \
+  esac \
+  && curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ytdlp_asset}" -o /usr/local/bin/yt-dlp \
+  && chmod +x /usr/local/bin/yt-dlp
+
+RUN dpkg --add-architecture i386 \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    wget \
+    software-properties-common \
+    lib32gcc-s1 \
+    lib32stdc++6 \
+    wine \
+    wine32:i386 \
+    wine64 \
+    libwine \
+    fonts-wine \
+    cabextract \
+    unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/steamcmd \
+  && wget -qO /tmp/steamcmd_linux.tar.gz "https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz" \
+  && tar -xzf /tmp/steamcmd_linux.tar.gz -C /opt/steamcmd \
+  && rm -f /tmp/steamcmd_linux.tar.gz \
+  && chmod -R 755 /opt/steamcmd
+
+RUN curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks" -o /usr/local/bin/winetricks \
+  && chmod +x /usr/local/bin/winetricks \
+  && useradd -m -d /home/wine -s /usr/sbin/nologin wine \
+  && install -d -m 0755 -o wine -g wine /home/wine/.wine
+
+RUN chmod +x /app/entrypoint.sh /usr/local/bin/steamcmd
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/LANCommander.Server/entrypoint.sh
+++ b/LANCommander.Server/entrypoint.sh
@@ -43,62 +43,30 @@ ensure_dir_owned() {
   install -d -m 0755 -o "$owner" -g "$group" "$path"
 }
 
-apt_update_once() {
-  # Run apt-get update only once per invocation when needed
-  if [[ -z "${_APT_UPDATED:-}" ]]; then
-    apt-get update
-    _APT_UPDATED=1
-  fi
-}
-
-apt_install() {
-  apt_update_once
-  apt-get install -y --no-install-recommends "$@"
-}
-
-# ---------- yt-dlp + ffmpeg ----------
-install_ytdlp() {
-  echo "Installing yt-dlp and ffmpeg..."
-
-  apt_install ffmpeg curl ca-certificates
-
-  if [[ -x "/usr/local/bin/yt-dlp" ]]; then
-    echo "yt-dlp already installed. Skipping download."
-  else
-    # Use the self-contained binary (bundles its own Python) instead of the
-    # bare "yt-dlp" zipapp asset, which requires a system python3.
-    case "$(uname -m)" in
-      x86_64|amd64)   ytdlp_asset="yt-dlp_linux" ;;
-      aarch64|arm64)  ytdlp_asset="yt-dlp_linux_aarch64" ;;
-      armv7l)         ytdlp_asset="yt-dlp_linux_armv7l" ;;
-      *)              ytdlp_asset="yt-dlp_linux" ;;
-    esac
-
-    echo "Downloading yt-dlp ($ytdlp_asset)..."
-    curl -fsSL "https://github.com/yt-dlp/yt-dlp/releases/latest/download/${ytdlp_asset}" -o /usr/local/bin/yt-dlp
-    chmod +x /usr/local/bin/yt-dlp
-    echo "yt-dlp installed."
-  fi
-}
-
 # ---------- SteamCMD ----------
 install_steamcmd() {
   echo "Installing SteamCMD..."
 
-  apt_install wget ca-certificates software-properties-common lib32gcc-s1 lib32stdc++6
+  if [[ "${LANCOMMANDER_FULL_IMAGE:-0}" == "1" ]]; then
+    STEAMCMD_DIR="/app/Data/Steam"
+    mkdir -p "$STEAMCMD_DIR/.steam/steamcmd"
+    if [[ ! -x "$STEAMCMD_DIR/steamcmd.sh" ]]; then
+      cp -a /opt/steamcmd/. "$STEAMCMD_DIR/"
+      chmod -R 755 "$STEAMCMD_DIR"
+    fi
+    echo "Full image detected; SteamCMD is available."
+    return 0
+  fi
 
-  # Create SteamCMD directory in /app/Data/Steam for persistence
+  apt-get update
+  apt-get install -y --no-install-recommends wget ca-certificates software-properties-common lib32gcc-s1 lib32stdc++6
+
   STEAMCMD_DIR="/app/Data/Steam"
-  mkdir -p "$STEAMCMD_DIR"
-  
-  # Create .steam directory for credential persistence
   mkdir -p "$STEAMCMD_DIR/.steam/steamcmd"
-  
-  # Set permissions to allow the app to use SteamCMD
   chmod -R 755 "$STEAMCMD_DIR"
 
   if [[ -x "$STEAMCMD_DIR/steamcmd.sh" ]]; then
-    echo "SteamCMD already present. Skipping download."
+    echo "SteamCMD already present."
   else
     echo "Downloading SteamCMD..."
     tmpdir="$(mktemp -d)"
@@ -109,10 +77,8 @@ install_steamcmd() {
     )
     rm -rf "$tmpdir"
     chmod +x "$STEAMCMD_DIR/steamcmd.sh"
-    echo "SteamCMD installed to $STEAMCMD_DIR."
   fi
-  
-  # Ensure .steam directory exists for credential persistence
+
   mkdir -p "$STEAMCMD_DIR/.steam/steamcmd"
   chmod -R 755 "$STEAMCMD_DIR/.steam"
 }
@@ -121,32 +87,29 @@ install_steamcmd() {
 install_wine() {
   echo "Installing WINE..."
 
-  if ! dpkg --print-foreign-architectures | grep -qx i386; then
-    dpkg --add-architecture i386
-    _APT_UPDATED=""   # force apt-get update to pull the i386 package lists
+  if [[ "${LANCOMMANDER_FULL_IMAGE:-0}" != "1" ]]; then
+    if ! dpkg --print-foreign-architectures | grep -qx i386; then
+      dpkg --add-architecture i386
+    fi
+
+    apt-get update
+    apt-get install -y --no-install-recommends wine wine32:i386 wine64 libwine fonts-wine cabextract unzip wget curl ca-certificates
   fi
 
-  apt_install wine wine32:i386 wine64 libwine fonts-wine cabextract unzip wget curl ca-certificates
-
-  # winetricks: install the self-contained upstream script.
   if [[ -x "/usr/local/bin/winetricks" ]]; then
     echo "winetricks already installed. Skipping download."
   else
-    echo "Downloading winetricks..."
     curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks" -o /usr/local/bin/winetricks
     chmod +x /usr/local/bin/winetricks
-    echo "winetricks installed."
   fi
 
   ensure_user "wine" "/home/wine"
   ensure_dir_owned "/home/wine/.wine" "wine" "wine"
 
-  # Initialize wine prefix once (headless-friendly)
   if [[ -f "/home/wine/.wine/system.reg" ]]; then
     echo "WINE prefix already initialized. Skipping winecfg."
   else
     echo "Initializing WINE prefix..."
-    # Suppress noisy logs and run a minimal init
     su -s /bin/bash -c 'WINEDEBUG=-all WINEARCH=win64 wineboot -u || true' wine
   fi
 
@@ -155,30 +118,18 @@ install_wine() {
 
 # ---------- Conditional execution (only if first run or explicitly requested again) ----------
 if [[ ! -f "$MARKER_FILE" ]]; then
-  install_ytdlp
-
   if [[ "${STEAMCMD:-0}" == "1" ]]; then
-    echo "STEAMCMD=1 detected, installing SteamCMD..."
     install_steamcmd
-  else
-    echo "STEAMCMD not set to 1, skipping SteamCMD installation."
   fi
 
   if [[ "${WINE:-0}" == "1" ]]; then
-    echo "WINE=1 detected, installing WINE..."
     install_wine
-  else
-    echo "WINE not set to 1, skipping WINE installation."
   fi
 
-  # Mark as completed
   date -Is > "$MARKER_FILE"
   echo "Setup steps completed. Marker written to $MARKER_FILE"
 else
-  # Even if previously completed, allow user to force re-run parts by setting REINSTALL=1
   if [[ "${REINSTALL:-0}" == "1" ]]; then
-    echo "REINSTALL=1 set — re-running requested installers if toggled."
-    install_ytdlp
     if [[ "${STEAMCMD:-0}" == "1" ]]; then install_steamcmd; fi
     if [[ "${WINE:-0}" == "1" ]]; then install_wine; fi
     date -Is > "$MARKER_FILE"

--- a/README.md
+++ b/README.md
@@ -94,9 +94,8 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
-      # Uncomment the line below to install SteamCMD
+      # Use lancommander/lancommander:latest-full for SteamCMD and WINE
       # - STEAMCMD=1
-      # Uncomment the line below to install WINE
       # - WINE=1
     volumes:
       - /path/to/app/data:/app/Data
@@ -113,13 +112,15 @@ All config and uploaded game archives are stored in `/app/Data`.
 
 Download the latest release for your platform from the [Releases](https://github.com/LANCommander/LANCommander/releases) page. The server is a self-contained binary with no external dependencies beyond a supported OS.
 
-### SteamCMD Support
+### SteamCMD and WINE Support
 
-The Docker image supports optional SteamCMD installation. Set `STEAMCMD=1` to enable it. SteamCMD will be installed in `/app/Data/Steam` with cached credentials persisted across container restarts.
+The default image includes yt-dlp and ffmpeg. SteamCMD and WINE are available in the `latest-full` image:
 
-### WINE Support
+```yaml
+image: lancommander/lancommander:latest-full
+```
 
-Set `WINE=1` to install WINE with wine32, wine64, and winetricks support in the Docker container.
+The default image can also install SteamCMD or WINE on first startup by setting `STEAMCMD=1` or `WINE=1`. SteamCMD is installed in `/app/Data/Steam` with cached credentials persisted across container restarts. The full image is currently published for amd64.
 
 > _Note: The Docker image runs the Linux build. Features such as server management may be limited._
 


### PR DESCRIPTION
## Summary

- Keep yt-dlp and ffmpeg in the base server image.
- Add a full amd64 image containing SteamCMD and WINE.
- Publish base and full images in parallel for development, nightly, and release workflows.
- Preserve runtime installation support for SteamCMD/WINE in the base image.
- Update Docker documentation with the `-full` image tag.

## Local image size comparison

| Image | Docker local display size | Uncompressed image size |
|---|---:|---:|
| `lancommander-server:base` | 2.44 GB | 686 MB |
| `lancommander-server:full` | 4.47 GB | 1.19 GB |

The full image adds approximately **503 MB uncompressed** (about **2.03 GB** in Docker's local storage display), primarily from WINE and its 32-bit dependencies.

## Validation

- Built both images locally after publishing the server for `linux-x64`.
- Validated updated workflow YAML and shell syntax.