### PR TITLE
Fix archive extraction ring buffer underflow

### DIFF
--- a/LANCommander.SDK/Clients/GameClient.cs
+++ b/LANCommander.SDK/Clients/GameClient.cs
@@ -91,6 +91,12 @@ namespace LANCommander.SDK.Services
         private const string PlayerAliasFilename = "PlayerAlias";
         private const string KeyFilename = "Key";
 
+        // The download stream is non-seekable, so SharpCompress uses a ring buffer to rewind while
+        // scanning entry headers. Archives with many small entries can require rewinding further than
+        // the library's default (160KB) buffer, throwing an ArchiveOperationException
+        // ("Ring buffer underflow"). Use a larger buffer to accommodate these cases.
+        private const int ArchiveRewindableBufferSize = 4 * 1024 * 1024;
+
         private static readonly TimeSpan ServerNotificationTimeout = TimeSpan.FromSeconds(15);
 
         private TrackableStream _transferStream;
@@ -434,7 +440,7 @@ namespace LANCommander.SDK.Services
                     });
                 });
 
-                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress }, cancellationToken);
+                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress, RewindableBufferSize = ArchiveRewindableBufferSize }, cancellationToken);
 
                 _installProgress.Status = InstallStatus.Downloading;
                 OnInstallProgressUpdate?.Invoke(_installProgress);
@@ -2024,7 +2030,7 @@ namespace LANCommander.SDK.Services
                     });
                 });
 
-                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress }, cancellationToken);
+                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress, RewindableBufferSize = ArchiveRewindableBufferSize }, cancellationToken);
 
                 _installProgress.Status = InstallStatus.Downloading;
                 OnInstallProgressUpdate?.Invoke(_installProgress);
@@ -2815,7 +2821,7 @@ namespace LANCommander.SDK.Services
             try
             {
                 var stream = await StreamLatestArchiveAsync(gameId);
-                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions(), cancellationToken);
+                _reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { RewindableBufferSize = ArchiveRewindableBufferSize }, cancellationToken);
 
                 while (await _reader.MoveToNextEntryAsync(cancellationToken))
                 {

--- a/LANCommander.SDK/Clients/RedistributableClient.cs
+++ b/LANCommander.SDK/Clients/RedistributableClient.cs
@@ -28,6 +28,12 @@ namespace LANCommander.SDK.Services
 
         public delegate void OnArchiveExtractionProgressHandler(long position, long length);
         public event OnArchiveExtractionProgressHandler OnArchiveExtractionProgress;
+
+        // The download stream is non-seekable, so SharpCompress uses a ring buffer to rewind while
+        // scanning entry headers. Archives with many small entries can require rewinding further than
+        // the library's default (160KB) buffer, throwing an ArchiveOperationException
+        // ("Ring buffer underflow"). Use a larger buffer to accommodate these cases.
+        private const int ArchiveRewindableBufferSize = 4 * 1024 * 1024;
         
         public delegate void OnInstallProgressUpdateHandler(InstallProgress e);
         public event OnInstallProgressUpdateHandler OnInstallProgressUpdate;
@@ -238,7 +244,7 @@ namespace LANCommander.SDK.Services
                         });
                     });
 
-                    await using var reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress }, cancellationToken);
+                    await using var reader = await ReaderFactory.OpenAsyncReader(stream, new ReaderOptions { Progress = progress, RewindableBufferSize = ArchiveRewindableBufferSize }, cancellationToken);
                     await reader.WriteAllToDirectoryAsync(destination, new ExtractionOptions()
                     {
                         ExtractFullPath = true,
@@ -351,7 +357,7 @@ namespace LANCommander.SDK.Services
                         });
                     });
 
-                    await using var reader = await ReaderFactory.OpenAsyncReader(redistributableStream, new ReaderOptions { Progress = progress }, cancellationToken);
+                    await using var reader = await ReaderFactory.OpenAsyncReader(redistributableStream, new ReaderOptions { Progress = progress, RewindableBufferSize = ArchiveRewindableBufferSize }, cancellationToken);
                     await reader.WriteAllToDirectoryAsync(destination, new ExtractionOptions()
                     {
                         ExtractFullPath = true,


### PR DESCRIPTION
## Why

Game installation could fail while extracting a valid ZIP archive from a server. SharpCompress reads the HTTP download as a non-seekable stream and may need to rewind farther than its default ring buffer while scanning entry headers, causing `ArchiveOperationException: Ring buffer underflow`.

## What changed

- Increase SharpCompress's `RewindableBufferSize` to 4 MB when opening network-backed archive readers.
- Apply the same setting to game extraction, selective game file downloads, and redistributable extraction paths.

The archive itself does not need to be repaired; this addresses the client-side streaming buffer limit.